### PR TITLE
Enforce pgEdge environment in login shells for install user

### DIFF
--- a/roles/init_server/tasks/environment.yaml
+++ b/roles/init_server/tasks/environment.yaml
@@ -8,7 +8,7 @@
 - name: Make sure to source .bashrc.d files on login
   blockinfile:
     path: "{{ ansible_user_dir }}/.bashrc"
-    insertafter: EOF
+    insertbefore: BOF
     state: present
     marker: "# {mark} pgEdge ANSIBLE MANAGED BLOCK"
     block: |


### PR DESCRIPTION
Moved the environment sourcing block to the top of .bashrc rather than the bottom due to some distributions imposing an early-exit at the top of the file if the shell is non-interactive.

Addresses GitHub issue #4.