### PR TITLE
Addressed issue with missing ipaddr utility dependency

### DIFF
--- a/galaxy.template.yml
+++ b/galaxy.template.yml
@@ -18,7 +18,8 @@ tags:
 - distributed
 - cluster
 
-dependencies: {}
+dependencies:
+  "ansible.utils": ">=2.5.0"
 
 repository: https://github.com/pgEdge/pgedge-ansible
 


### PR DESCRIPTION
This collection makes use of the ansible.utils.ipaddr filter. This specific filter was added to version 2.5.0 of the ansible.utils collection. However, this collection was not considered "default" until Ansible 2.15, so may not be included. Added an explicit dependency to ensure ansible-galaxy installs it.

Addresses Jira issue EE-1.