### PR TITLE
Extended package installation timeout to 5 minutes.

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
 
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12.0'

--- a/roles/init_server/tasks/packages.yaml
+++ b/roles/init_server/tasks/packages.yaml
@@ -8,4 +8,5 @@
     - rsync
     - "{{ 'kernel-modules-extra' if ansible_facts.os_family == 'RedHat' else 'systemd-coredump' }}"
     state: present
+    lock_timeout: 300
   become: true

--- a/roles/install_patroni/tasks/packages.yaml
+++ b/roles/install_patroni/tasks/packages.yaml
@@ -5,6 +5,7 @@
     name:
     - python3-psycopg2
     state: present
+    lock_timeout: 300
   become: true
 
 - name: Include Packages Patroni needs to run or operate on Debian systems
@@ -12,5 +13,6 @@
     name:
     - python3-venv
     state: present
+    lock_timeout: 300
   become: true
   when: ansible_facts.os_family == 'Debian'

--- a/roles/setup_haproxy/tasks/packages.yaml
+++ b/roles/setup_haproxy/tasks/packages.yaml
@@ -5,4 +5,5 @@
     name:
     - haproxy
     state: present
+    lock_timeout: 300
   become: true


### PR DESCRIPTION
On freshly provisioned servers or VMs, background package management may hold an extended lock that could disrupt an Ansible playbook which needs to install packages. The default timeout of 30s is not sufficient for this, and adding a wait step seems excessive. The lock_timeout parameter is supported by both dnf and apt modules, and the package module passes it along as is.

Addresses Jira issue EE-8.