### PR TITLE
Add multiple-database functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ All of the roles are meant to operate in conjunction. They are simplified to red
 
 | **Parameter** | **Default** | **Description**                                     |
 |---------------|-------------|-----------------------------------------------------|
+| cluster_name | demo | Canonical name for the cluster, primarily used for descriptive items and generated values. |
 | repo_name | download | Can be one of `download`, `upstream`, or `devel`. This will control which pgEdge repository is used for software installation. |
 | repo_prefix | None | If set, makes it possible to install specific custom or automated builds based on repository prefix. Consult a member of pgEdge staff for valid setting here. |
 | zone | 1 | Zone or region for a node. This helps organize HA clusters. It also doubles as the snowflake ID of a node. For non-HA clusters, just use one node per zone. |
 | pg_version | 16 | Postgres version to install. This is left at 16 to facilitate upgrade tests. |
 | spock_version | 4.0.9 | Version of the Spock extension to install. |
-| db_name | demo | Name of the database to use for the Spock cluster. |
+| db_names | demo | List of database names to use for the Spock cluster. At least one database name is expected to initialize the cluster. Any missing databases will be created and owned by `db_user`. |
 | db_user | admin | Database username. Must be something other than the OS username performing the installation. Note that the CLI will create a database user named after the OS user for its own purposes as part of the installation and setup process. |
 | db_password | secret | Password for the `db_user` user. |
 | is_ha_cluster | false | If true, install etcd and Patroni on all nodes in the `pgedge` group. If HAProxy nodes exist, they will reflect nodes in the same zone. Subscriptions from other pgEdge nodes will also pass through the zone HAProxy. |

--- a/roles/role_config/defaults/main.yaml
+++ b/roles/role_config/defaults/main.yaml
@@ -1,11 +1,13 @@
 ---
 
+cluster_name: demo
 repo_name: download
 repo_prefix: ""
 zone: 1
 pg_version: 16
 spock_version: "4.0.9"
-db_name: demo
+db_names:
+- demo
 db_user: admin
 db_password: secret
 

--- a/roles/setup_backrest/defaults/main.yaml
+++ b/roles/setup_backrest/defaults/main.yaml
@@ -4,7 +4,7 @@ backup_host: ''
 
 backup_repo_type: ssh
 backup_repo_path: "{{ cluster_path }}/data/backrest"
-backup_repo_cipher: "{{ lookup('password', '/dev/null length=20', seed='pgedge' + db_name + '-' + zone | string) }}"
+backup_repo_cipher: "{{ lookup('password', '/dev/null length=20', seed='pgedge' + cluster_name + '-' + zone | string) }}"
 backup_repo_cipher_type: aes-256-cbc
 
 full_backup_count: 1

--- a/roles/setup_backrest/files/pgbackrest.conf.j2
+++ b/roles/setup_backrest/files/pgbackrest.conf.j2
@@ -1,4 +1,4 @@
-[pgedge-{{ db_name }}-{{ zone }}]
+[pgedge-{{ cluster_name }}-{{ zone }}]
 
 {% if inventory_hostname in groups.backup %}
 # This is a backup server, so list all hosts in the zone as backup targets
@@ -7,14 +7,14 @@ pg{{ loop.index }}-host={{ hostvars[item].inventory_hostname }}
 pg{{ loop.index }}-host-user={{ ansible_user_id }}
 pg{{ loop.index }}-path={{ pg_data }}
 pg{{ loop.index }}-user={{ ansible_user_id }}
-pg{{ loop.index }}-database={{ db_name }}
+pg{{ loop.index }}-database=postgres
 {% endfor %}
 {% else %}
 # Nodes should only know about themselves. This prevents replicas from
 # reaching into the primary node to start a backup procedure.
 pg1-path={{ pg_data }}
 pg1-user={{ ansible_user_id }}
-pg1-database={{ db_name }}
+pg1-database=postgres
 {% endif %}
 
 [global]

--- a/roles/setup_backrest/tasks/config_postgres.yaml
+++ b/roles/setup_backrest/tasks/config_postgres.yaml
@@ -6,7 +6,7 @@
     line: "{{ item.var }} = '{{ item.setting }}'"
     regexp: "^{{ item.var }}[ =].*"
   vars:
-    stanza: "pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "pgedge-{{ cluster_name }}-{{ zone }}"
     cmd: "LD_LIBRARY_PATH={{ pg_path }}/lib {{ cluster_path }}/backrest/bin/pgbackrest"
     push_args: "--stanza={{ stanza }} archive-push %p"
     pull_args: "--stanza={{ stanza }} archive-get %f %p"

--- a/roles/setup_backrest/tasks/config_postgres_ha.yaml
+++ b/roles/setup_backrest/tasks/config_postgres_ha.yaml
@@ -17,7 +17,7 @@
                --apply patroni.patch pgedge
     rm patroni.patch
   vars:
-    stanza: "pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "pgedge-{{ cluster_name }}-{{ zone }}"
     cmd: "LD_LIBRARY_PATH={{ pg_path }}/lib {{ cluster_path }}/backrest/bin/pgbackrest"
     push_args: "--stanza={{ stanza }} archive-push %p"
     pull_args: "--stanza={{ stanza }} archive-get %f %p"

--- a/roles/setup_backrest/tasks/first_backup.yaml
+++ b/roles/setup_backrest/tasks/first_backup.yaml
@@ -4,7 +4,7 @@
   shell: |
     {{ cluster_path }}/backrest/bin/pgbackrest {{ stanza }} stanza-create
   vars:
-    stanza: "--stanza=pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "--stanza=pgedge-{{ cluster_name }}-{{ zone }}"
   environment:
     LD_LIBRARY_PATH: "{{ pg_path }}/lib"
 
@@ -16,6 +16,6 @@
   shell: |
     {{ cluster_path }}/backrest/bin/pgbackrest {{ stanza }} backup --type=full
   vars:
-    stanza: "--stanza=pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "--stanza=pgedge-{{ cluster_name }}-{{ zone }}"
   environment:
     LD_LIBRARY_PATH: "{{ pg_path }}/lib"

--- a/roles/setup_backrest/tasks/set_cron.yaml
+++ b/roles/setup_backrest/tasks/set_cron.yaml
@@ -1,5 +1,13 @@
 ---
 
+- name: Make sure cron is actually installed before trying to use it...
+  package:
+    name:
+    - cron
+    state: present
+    lock_timeout: 300
+  become: true
+
 - name: Set PgBackRest library path in crontab
   cron:
     name: LD_LIBRARY_PATH
@@ -16,7 +24,7 @@
     weekday: "{{ full_backup_schedule.split(' ')[4] }}"
     job: '{{ cluster_path }}/backrest/bin/pgbackrest {{ stanza }} backup --type=full'
   vars:
-    stanza: "--stanza=pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "--stanza=pgedge-{{ cluster_name }}-{{ zone }}"
   when: full_backup_schedule.split(' ') | length == 5
 
 - name: Set PgBackRest differential backup schedule
@@ -29,5 +37,5 @@
     weekday: "{{ diff_backup_schedule.split(' ')[4] }}"
     job: '{{ cluster_path }}/backrest/bin/pgbackrest {{ stanza }} backup --type=diff'
   vars:
-    stanza: "--stanza=pgedge-{{ db_name }}-{{ zone }}"
+    stanza: "--stanza=pgedge-{{ cluster_name }}-{{ zone }}"
   when: diff_backup_schedule.split(' ') | length == 5

--- a/roles/setup_pgedge/tasks/ha_setup.yaml
+++ b/roles/setup_pgedge/tasks/ha_setup.yaml
@@ -4,8 +4,9 @@
   shell: |
     cd {{ cluster_path }}
     ./pgedge spock node-create edge{{ zone }}  \
-      'host={{ subscribe_target }} user={{ ansible_user_id }} dbname={{ db_name }}' \
-      {{ db_name }}
+      'host={{ subscribe_target }} user={{ ansible_user_id }} dbname={{ item }}' \
+      {{ item }}
+  loop: "{{ db_names }}"
 
 # Loop through every _other_ zone than our own and subscribe in this order:
 #
@@ -19,21 +20,21 @@
 - name: Subscribe to any other pgEdge nodes in the cluster, by zone
   shell: |
     cd {{ cluster_path }}
-    ./pgedge spock sub-create sub_n{{ zone }}_n{{ item }}  \
-      'host={{ conn_target }} user={{ ansible_user_id }} dbname={{ db_name }}' \
-      {{ db_name }}
+    ./pgedge spock sub-create sub_n{{ zone }}_n{{ item.0 }}  \
+      'host={{ conn_target }} user={{ ansible_user_id }} dbname={{ item.1 }}' \
+      {{ item.1 }}
   vars:
     remote_first_node: >-
       {{ groups['pgedge'] |
       map('extract', hostvars) |
-      selectattr('zone', 'eq', item) |
+      selectattr('zone', 'eq', item.0) |
       map(attribute='inventory_hostname') | list | first }}
     remote_proxy_node: >-
       {{ hostvars[remote_first_node].proxy_node | default('') }}
     remote_proxies: >-
       {{ groups['haproxy'] | default(()) |
       map('extract', hostvars) |
-      selectattr('zone', 'eq', item) |
+      selectattr('zone', 'eq', item.0) |
       map(attribute='inventory_hostname') | list }}
     conn_target: >-
       {{ remote_proxy_node if remote_proxy_node > ''
@@ -43,4 +44,4 @@
   delay: 10
   register: subscription
   until: subscription.rc == 0
-  loop: "{{ zone_list | reject('equalto', zone) }}"
+  loop: "{{ zone_list | reject('equalto', zone) | product(db_names) | list }}"

--- a/roles/setup_pgedge/tasks/setup.yaml
+++ b/roles/setup_pgedge/tasks/setup.yaml
@@ -4,8 +4,9 @@
   shell: |
     cd {{ cluster_path }}
     ./pgedge spock node-create edge{{ zone }}  \
-      'host={{ inventory_hostname }} user={{ ansible_user_id }} dbname={{ db_name }}' \
-      {{ db_name }}
+      'host={{ inventory_hostname }} user={{ ansible_user_id }} dbname={{ item }}' \
+      {{ item }}
+  loop: "{{ db_names }}"
 
 - name: Set Spock to handle transaction exceptions
   shell: |
@@ -25,13 +26,17 @@
     ./pgedge db guc-set spock.include_ddl_repset on
 
 # Loop through every other known pgEdge node and subscribe to it.
+# This is technically a nested loop, since we need to subscribe to each DB on
+# every node.
 
-- name: Subscribe to any other pgEdge nodes in the cluster, by zone
+- name: Subscribe to other pgEdge nodes and databases in the cluster, by zone
   shell: |
     cd {{ cluster_path }}
     ./pgedge spock sub-create sub_n{{ zone }}_n{{ remote_zone }}  \
-      'host={{ item }} user={{ ansible_user_id }} dbname={{ db_name }}' \
-      {{ db_name }}
+      'host={{ item.0 }} user={{ ansible_user_id }} dbname={{ item.1 }}' \
+      {{ item.1 }}
   vars:
-    remote_zone: "{{ hostvars[item]['zone'] }}"
-  loop: "{{ groups['pgedge'] | reject('equalto', inventory_hostname) }}"
+    remote_zone: "{{ hostvars[item.0]['zone'] }}"
+  loop: >-
+    {{ groups['pgedge'] | reject('equalto', inventory_hostname) | 
+    product(db_names) | list }}

--- a/roles/setup_postgres/tasks/setup.yaml
+++ b/roles/setup_postgres/tasks/setup.yaml
@@ -1,11 +1,29 @@
 ---
 
+# Bootstrap the installation with the first DB name in the list. This list is
+# usually just one item anyway.
+
 - name: Install and set up Postgres using pgedge CLI
   shell: |
     cd {{ cluster_path }}
-    ./pgedge setup -d {{ db_name }} \
+    ./pgedge setup -d {{ db_names | first }} \
         -U {{ db_user }} -P {{ db_password }} \
         --pg_ver {{ pg_version }} \
         --spock_ver {{ spock_version }}
   args:
     creates: "{{ pg_path }}"
+
+# Since we created the instance using the first database name, ensure each
+# remaining database exists and contains the spock and snowflake extensions.
+# Add a gratuitous database name check to avoid additional executions.
+
+- name: Bootstrap additional requested databases
+  shell: |
+    cd {{ pg_path }}/bin
+    db_check=$(./psql -qAtl | cut -d'|' -f 1 | grep {{ item }} | cat)
+    if [ "$db_check" != "{{ item }}" ]; then
+      ./createdb -O {{ db_user }} {{ item }}
+      ./psql -c "CREATE EXTENSION IF NOT EXISTS spock;" {{ item }}
+      ./psql -c "CREATE EXTENSION IF NOT EXISTS snowflake;" {{ item }}
+    fi
+  loop: "{{ db_names[1:] }}"


### PR DESCRIPTION
If users want to have a cluster containing multiple databases, the CLI tool won't do this natively. We need to add loops in strategic areas to add all of the additional databases beyond the initial one used to bootstrap the installation. This change hits all of the required areas and also subsequently renames the `db_name` parmaeter to `db_names`.

Additionally added a task to install cron on minimal systems.

Addresses Jira issue EE-12.