### PR TITLE
Fixing package management for Debian

### DIFF
--- a/roles/init_server/tasks/packages.yaml
+++ b/roles/init_server/tasks/packages.yaml
@@ -1,5 +1,10 @@
 ---
 
+- name: Update package cache
+  package:
+    update_cache: true
+  become: true
+
 - name: Include all the packages which should be installed everywhere
   package:
     name:

--- a/roles/init_server/tasks/packages.yaml
+++ b/roles/init_server/tasks/packages.yaml
@@ -1,10 +1,5 @@
 ---
 
-- name: Update package cache
-  package:
-    update_cache: true
-  become: true
-
 - name: Include all the packages which should be installed everywhere
   package:
     name:
@@ -14,4 +9,9 @@
     - "{{ 'kernel-modules-extra' if ansible_facts.os_family == 'RedHat' else 'systemd-coredump' }}"
     state: present
     lock_timeout: 300
+    update_cache: true
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
   become: true

--- a/roles/install_patroni/tasks/packages.yaml
+++ b/roles/install_patroni/tasks/packages.yaml
@@ -1,18 +1,38 @@
 ---
 
+- name: Wait until dpkg unlocks
+  shell: |
+    fuser -v /var/lib/dpkg/lock-frontend
+  become: true
+  register: lock_result
+  until: lock_result.rc == 1
+  retries: 60
+  delay: 2
+  failed_when: lock_result.rc == 0
+  when: ansible_facts.os_family == 'Debian'
+
 - name: Include Packages Patroni needs to run or operate
   package:
     name:
     - python3-psycopg2
     state: present
-    lock_timeout: 300
   become: true
+
+- name: Wait until dpkg unlocks
+  shell: |
+    fuser -v /var/lib/dpkg/lock-frontend
+  become: true
+  register: lock_result
+  until: lock_result.rc == 1
+  retries: 60
+  delay: 2
+  failed_when: lock_result.rc == 0
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Include Packages Patroni needs to run or operate on Debian systems
   package:
     name:
     - python3-venv
     state: present
-    lock_timeout: 300
   become: true
   when: ansible_facts.os_family == 'Debian'

--- a/roles/install_patroni/tasks/packages.yaml
+++ b/roles/install_patroni/tasks/packages.yaml
@@ -1,38 +1,26 @@
 ---
 
-- name: Wait until dpkg unlocks
-  shell: |
-    fuser -v /var/lib/dpkg/lock-frontend
-  become: true
-  register: lock_result
-  until: lock_result.rc == 1
-  retries: 60
-  delay: 2
-  failed_when: lock_result.rc == 0
-  when: ansible_facts.os_family == 'Debian'
-
 - name: Include Packages Patroni needs to run or operate
   package:
     name:
     - python3-psycopg2
     state: present
+    lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
   become: true
-
-- name: Wait until dpkg unlocks
-  shell: |
-    fuser -v /var/lib/dpkg/lock-frontend
-  become: true
-  register: lock_result
-  until: lock_result.rc == 1
-  retries: 60
-  delay: 2
-  failed_when: lock_result.rc == 0
-  when: ansible_facts.os_family == 'Debian'
 
 - name: Include Packages Patroni needs to run or operate on Debian systems
   package:
     name:
     - python3-venv
     state: present
+    lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
   become: true
   when: ansible_facts.os_family == 'Debian'

--- a/roles/setup_backrest/tasks/set_cron.yaml
+++ b/roles/setup_backrest/tasks/set_cron.yaml
@@ -6,6 +6,10 @@
     - cron
     state: present
     lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
   become: true
 
 - name: Set PgBackRest library path in crontab

--- a/roles/setup_haproxy/tasks/packages.yaml
+++ b/roles/setup_haproxy/tasks/packages.yaml
@@ -6,4 +6,8 @@
     - haproxy
     state: present
     lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
   become: true


### PR DESCRIPTION
Ran into a couple issues with the latest version:

 - If a server hasn't had its packages updated before running the `init_server` tasks it may fail because the packages aren't in the cached list. 
 - The `lock_timeout` for the package task does not seem to work, so I replaced it with a manual dpkg lock check for Debian machines