### PR TITLE
Addressed issue with replication user password management.

### DIFF
--- a/galaxy.template.yml
+++ b/galaxy.template.yml
@@ -20,6 +20,7 @@ tags:
 
 dependencies:
   "ansible.utils": ">=2.5.0"
+  "community.postgresql": ">=2.4.0"
 
 repository: https://github.com/pgEdge/pgedge-ansible
 

--- a/roles/setup_patroni/files/patroni.yaml.j2
+++ b/roles/setup_patroni/files/patroni.yaml.j2
@@ -71,8 +71,8 @@ postgresql:
 
   pg_hba:
   - local all {{ ansible_user_id }} peer
-  - host replication replicator {{ ip_mask }} scram-sha-256
-  - host replication replicator 127.0.0.1/32 scram-sha-256
+  - host replication {{ replication_user }} {{ ip_mask }} scram-sha-256
+  - host replication {{ replication_user }} 127.0.0.1/32 scram-sha-256
   - host all all 0.0.0.0/0 scram-sha-256
 
   authentication:

--- a/roles/setup_postgres/tasks/main.yaml
+++ b/roles/setup_postgres/tasks/main.yaml
@@ -8,11 +8,16 @@
 - include_tasks: setup.yaml
   when: not pg_installed.stat.exists
 
+- include_tasks: packages.yaml
+
 - include_tasks: environment.yaml
+
+- include_tasks: prep_primary.yaml
+  when:
+  - is_ha_cluster
+  - inventory_hostname == first_node_in_zone
 
 - include_tasks: prep_replicas.yaml
   when:
   - is_ha_cluster
   - inventory_hostname != first_node_in_zone
-
-

--- a/roles/setup_postgres/tasks/packages.yaml
+++ b/roles/setup_postgres/tasks/packages.yaml
@@ -1,0 +1,13 @@
+---
+
+- name: Include psycopg2 for Postgres administration uses
+  package:
+    name:
+    - python3-psycopg2
+    state: present
+    lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
+  become: true

--- a/roles/setup_postgres/tasks/prep_primary.yaml
+++ b/roles/setup_postgres/tasks/prep_primary.yaml
@@ -1,0 +1,14 @@
+---
+
+# The pgedge CLI will create a 'replicator' user, but this may not be what
+# the role user requested. Create this user explicitly on the primary node.
+# If this is still the default user, the password will be changed instead.
+
+- name: Create user for replication
+  community.postgresql.postgresql_user:
+    login_user: "{{ ansible_user_id }}"
+    login_db: postgres
+    name: "{{ replication_user }}"
+    password: "{{ replication_password }}"
+    role_attr_flags: REPLICATION
+    login_unix_socket: /tmp


### PR DESCRIPTION
Previously this collection assumed the pgEdge CLI set up the replicator user as the desired default user to use for replication, but also provided a method for overriding with the replication_user parameter. Now the replication_user and replication_password params explicitly define and create a new user/pass combination independent of any side-effects from the CLI, specific for physical replication. Further, any areas where the "replicator" user were hard-coded have been replaced by the replication_user parameter as expected.

Addresses Jira issue EE-14.