### PR TITLE
Added AWS S3 backup target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ All of the roles are meant to operate in conjunction. They are simplified to red
 | debug_pgedge | true | When enabled, various kernel settings will be configured to retain all core files produced during a process crash. |
 | manage_host_file | true | When enabled, all hosts in the cluster will be listed in the `/etc/hosts` file of every other host. Set to false if external DNS is in use, or inventory hostnames are IP addresses. |
 | backup_host | '' | Should be set to the hostname where PgBackRest backups should be transmitted. If left empty and `backup_repo_type` is ssh, will default to the first node in the `backup` node group in the same zone. |
-| backup_repo_type | ssh | The type of PgBackRest backup repository to use. Using 'ssh' means backups are stored on a dedicated backup server as defined in the `backup` host group. Other options will be added soon. |
-| backup_repo_path | `$cluster_path/data/backrest` | Full path to storage location of PgBackRest repository. |
+| backup_repo_type | ssh | The type of PgBackRest backup repository to use. Using 'ssh' means backups are stored on a dedicated backup server as defined in the `backup` host group. Using 's3' will use a remote AWS S3 bucket and requires `backup_repo_params` to be set. Other options will be added as requested. |
+| backup_repo_path | `$cluster_path/data/backrest` | Full path to storage location of PgBackRest repository. If using S3 as a repo type, set this to something simple like `/backrest`. |
 | backup_repo_cipher_type | aes-256-cbc | Encryption algorithm to use for backup files stored in the PgBackRest repository. |
 | backup_repo_cipher | (random) | This should be specified and will define the encryption cipher used for backup files stored in the PgBackRest repository. If not defined, will be set to a 20-character deterministic random string based on the backup repository name. |
 | full_backup_count | 1 | Defines how many full backups to retain in the backup repository. |
 | diff_backup_count | 6 | Defines how many differential backups to retain in the backup repository. |
 | full_backup_schedule | `10 0 * * 0` | Defines a cron-style schedule for automating full PgBackRest backup operations. The default will run every Sunday at 10 minutes after midnight.
 | diff_backup_schedule | `10 0 * * 0` | Defines a cron-style schedule for automating differential PgBackRest backup operations. The default will run every Monday - Saturday at 10 minutes after midnight. |
+| backup_repo_params | See description | Parameters to remote backup repositories (S3 for now). Should be a dictionary with the following fields (defaults listed): `{ region: us-east-1, endpoint: s3.amazonaws.com, bucket: pgbackrest, access_key: '', secret_key: '' }`. |
 | exception_behaviour | transdiscard | Defines what Spock should do when it encounters an exception. Default is `transdiscard` to skip offending transaction. See [documentation](https://docs.pgedge.com/platform/exception#spockexception_behaviour). |
 
 Modifying other parameters will have no effect on the cluster.

--- a/roles/setup_backrest/defaults/main.yaml
+++ b/roles/setup_backrest/defaults/main.yaml
@@ -7,6 +7,8 @@ backup_repo_path: "{{ cluster_path }}/data/backrest"
 backup_repo_cipher: "{{ lookup('password', '/dev/null length=20', seed='pgedge' + cluster_name + '-' + zone | string) }}"
 backup_repo_cipher_type: aes-256-cbc
 
+backup_repo_params: {}
+
 full_backup_count: 1
 diff_backup_count: 6
 full_backup_schedule: "10 0 * * 0"

--- a/roles/setup_backrest/files/pgbackrest.conf.j2
+++ b/roles/setup_backrest/files/pgbackrest.conf.j2
@@ -1,6 +1,6 @@
 [pgedge-{{ cluster_name }}-{{ zone }}]
 
-{% if inventory_hostname in groups.backup %}
+{% if groups.backup is defined and inventory_hostname in groups.backup %}
 # This is a backup server, so list all hosts in the zone as backup targets
 {% for item in nodes_in_zone %}
 pg{{ loop.index }}-host={{ hostvars[item].inventory_hostname }}
@@ -28,9 +28,18 @@ repo1-cipher-pass={{ backup_repo_cipher }}
 
 {% if backup_type == 'ssh' %}
 repo1-hardlink=y
-{%   if inventory_hostname not in groups.backup %}
+{%   if groups.backup is defined and inventory_hostname not in groups.backup %}
 repo1-type=posix
 repo1-host={{ backup_server }}
 repo1-host-user={{ ansible_user_id }}
 {%   endif %}
+{% endif %}
+
+{% if backup_type == 's3' %}
+repo1-type=s3
+repo1-s3-region={{ backup_params.region }}
+repo1-s3-endpoint={{ backup_params.endpoint }}
+repo1-s3-bucket={{ backup_params.bucket }}
+repo1-s3-key={{ backup_params.access_key }}
+repo1-s3-key-secret={{ backup_params.secret_key }}
 {% endif %}

--- a/roles/setup_backrest/tasks/main.yaml
+++ b/roles/setup_backrest/tasks/main.yaml
@@ -12,6 +12,7 @@
   - include_tasks: setup_server.yaml
     when:
     - backup_type == 'ssh'
+    - groups.backup is defined
     - inventory_hostname in groups.backup
 
   - include_tasks: config_postgres.yaml
@@ -29,8 +30,9 @@
 
   - include_tasks: first_backup.yaml
     when:
+    - groups.backup is defined
     - inventory_hostname in groups.backup
-    
+
   - include_tasks: first_backup.yaml
     when:
     - backup_type != 'ssh'
@@ -47,10 +49,11 @@
 
   - include_tasks: set_cron.yaml
     when:
+    - groups.backup is defined
     - inventory_hostname in groups.backup
 
   - include_tasks: set_cron.yaml
     when:
     - backup_type != 'ssh'
 
-  when: backup_server > ''
+  when: backup_server > '' or backup_type != 'ssh'

--- a/roles/setup_backrest/tasks/set_cron.yaml
+++ b/roles/setup_backrest/tasks/set_cron.yaml
@@ -3,7 +3,7 @@
 - name: Make sure cron is actually installed before trying to use it...
   package:
     name:
-    - cron
+    - "{{ 'cronie' if ansible_facts.os_family == 'RedHat' else 'cron' }}"
     state: present
     lock_timeout: 300
   retries: 5

--- a/roles/setup_backrest/vars/main.yaml
+++ b/roles/setup_backrest/vars/main.yaml
@@ -3,9 +3,18 @@
 backup_type: "{{ backup_repo_type if backup_repo_type in ('ssh', 's3') else 'ssh' }}"
 
 default_backup_server: >-
-  {{ groups['backup'] |
+  {{ groups['backup'] | default(()) |
   map('extract', hostvars) |
   selectattr('zone', 'eq', zone) |
   map(attribute='inventory_hostname') | list | first | default('') }}
 
 backup_server: "{{ backup_host or default_backup_server }}"
+
+default_repo_params:
+  region: "us-east-1"
+  endpoint: "s3.amazonaws.com"
+  bucket: "pgbackrest"
+  access_key: ""
+  secret_key: ""
+
+backup_params: "{{ default_repo_params | combine(backup_repo_params) }}"


### PR DESCRIPTION
There were provisions in earlier iterations of the setup_backrest role which allowed for repo types other than ssh. This makes it "official" by adding S3 support which requires a new backup_repo_params dictionary with the following structure and defaults:

    backup_repo_params:
      region: "us-east-1"
      endpoint: "s3.amazonaws.com"
      bucket: "pgbackrest"
      access_key: ""
      secret_key: ""

Also fixed a package issue with RedHat systems which apparently install cronie rather than cron.

Addresses Jira issue EE-4.