### PR TITLE
Switched etcd and Patroni to using upstream packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to specify additional HAProxy listeners for specific Patroni node types. (EE-9)
+- Restart Postgres in setup_patroni role to activate config changes. (EE-13)
+
+### Changed
+
+- Switched to upstream etcd and Patroni releases. (EE-15)
+
 
 ## v0.1.0
 

--- a/roles/install_etcd/defaults/main.yaml
+++ b/roles/install_etcd/defaults/main.yaml
@@ -1,1 +1,13 @@
 ---
+
+etcd_version: "3.6.2"
+etcd_base_url: "https://github.com/etcd-io/etcd/releases/download/v{{ etcd_version }}"
+etcd_checksum: "sha256:{{ etcd_base_url }}/SHA256SUMS"
+etcd_package: "etcd-v{{ etcd_version }}-linux-amd64"
+etcd_install_dir: "{{ cluster_path }}/etcd"
+
+etcd_user: etcd
+etcd_group: etcd
+etcd_install_dir: "/usr/local/etcd"
+etcd_config_dir: "/etc/etcd"
+etcd_data_dir: "/var/lib/etcd"

--- a/roles/install_etcd/files/etcd.service.j2
+++ b/roles/install_etcd/files/etcd.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=etcd key-value store
+Documentation=https://github.com/etcd-io/etcd
+After=network.target
+
+[Service]
+User={{ etcd_user }}
+Type=notify
+Environment=ETCD_DATA_DIR={{ etcd_data_dir }}
+Environment=ETCD_NAME=%m
+ExecStart={{ etcd_install_dir }}/etcd --config-file {{ etcd_config_dir }}/etcd.yaml
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/install_etcd/tasks/environment.yaml
+++ b/roles/install_etcd/tasks/environment.yaml
@@ -3,5 +3,5 @@
 - name: Add etcd utilities to the user path
   lineinfile:
     path: "{{ ansible_facts['user_dir'] }}/.bashrc.d/etcd_env.sh"
-    line: "export PATH=${PATH}:/usr/local/etcd"
+    line: "export PATH=${PATH}:{{ etcd_install_dir }}"
     create: true

--- a/roles/install_etcd/tasks/install.yaml
+++ b/roles/install_etcd/tasks/install.yaml
@@ -1,15 +1,73 @@
 ---
 
-- name: Check for pre-existing etcd installation
-  shell: |
-    cd {{ cluster_path }}
-    ./pgedge um list | grep -q etcd | grep -q Installed | cat
-  register: etcd_download
+# Add the etcd data dir as the user's home. Should we ever "sudo" to this
+# user, the only thing relevant is the data directory. This also has the side
+# effect of creating the directory itself.
 
-- name: Download / install pgEdge etcd package to server
-  shell: |
-    cd {{ cluster_path }}
-    ./pgedge um install etcd
-  when: etcd_download.stdout == ''
-  args:
-    creates: /etc/systemd/system/etcd.service
+- name: Add the etcd service user
+  user:
+    name: "{{ etcd_user }}"
+    home: "{{ etcd_data_dir }}"
+    shell: "/bin/bash"
+    system: true
+  become: true
+
+- name: Create temp work space if it doesn't exist
+  file:
+    path: "{{ cluster_path }}/tmp"
+    state: directory
+    mode: 0700
+
+# It feels a bit strange installing binaries directly from github rather than
+# Hashicorp, but if they don't want to distribute their own binaries, that's
+# on them. We can at least enforce the checksum for the download. The URL
+# is a variable so users can supply their own repo URL for isolated networks.
+
+- name: Download latest etcd binary package
+  get_url:
+    url: "{{ etcd_base_url }}/{{ etcd_package }}.tar.gz"
+    dest: "{{ cluster_path }}/tmp/{{ etcd_package }}.tar.gz"
+    checksum: "{{ etcd_checksum }}"
+    mode: "0600"
+
+- name: Extract etcd archive
+  unarchive:
+    src: "{{ tmp_dir }}/{{ etcd_package }}.tar.gz"
+    dest: "{{ tmp_dir }}"
+    remote_src: true
+    creates: "{{ tmp_dir }}/{{ etcd_package }}"
+  vars:
+    tmp_dir: "{{ cluster_path }}/tmp"
+
+- name: Install etcd binaries to expected location
+  copy:
+    src: "{{ cluster_path }}/tmp/{{ etcd_package }}/"
+    dest: "{{ etcd_install_dir }}/"
+    mode: "0755"
+    remote_src: true
+  become: true
+
+# Some systems may have a system-wide umask set, in which case these binaries
+# may not be executable post-install. This step ensures non-root users can run
+# etcd services.
+
+- name: Make sure the etcd binaries are executable
+  file:
+    path: "{{ etcd_install_dir }}/{{ item }}"
+    mode: "0755"
+  become: true
+  loop:
+  - etcd
+  - etcdctl
+  - etcdutl
+
+# The service file is being installed here, but is not being enabled.
+# The setup_etcd role should do that.
+
+- name: Install the etcd Systemd service file
+  template:
+    src: files/etcd.service.j2
+    dest: /etc/systemd/system/etcd.service
+    owner: "{{ etcd_user }}"
+    group: "{{ etcd_group }}"
+  become: true

--- a/roles/install_etcd/tasks/main.yaml
+++ b/roles/install_etcd/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 
-- name: Check for etcd software
+- name: Check for etcd binary
   stat:
-    path: "/usr/local/etcd"
-  register: etcd_software
+    path: "{{ etcd_install_dir }}/etcd"
+  register: etcd_binary
 
 - include_tasks: install.yaml
-  when: not etcd_software.stat.exists
+  when: not etcd_binary.stat.exists
 
 - include_tasks: environment.yaml

--- a/roles/install_patroni/defaults/main.yaml
+++ b/roles/install_patroni/defaults/main.yaml
@@ -1,1 +1,4 @@
 ---
+
+patroni_bin_dir: "{{ ansible_facts['user_dir'] }}/.local/bin"
+patroni_config_dir: "/etc/patroni"

--- a/roles/install_patroni/files/patroni.service.j2
+++ b/roles/install_patroni/files/patroni.service.j2
@@ -1,0 +1,29 @@
+[Unit]
+Description=Patroni service to orchestrate high availability of pgEdge nodes
+After=syslog.target network.target
+
+[Service]
+Type=simple
+
+User={{ ansible_user_id }}
+
+ExecStart={{ patroni_bin_dir }}/patroni {{ patroni_config_dir }}/patroni.yaml
+
+# Send HUP to reload from patroni.yaml
+
+ExecReload=/bin/kill -s HUP $MAINPID
+
+# Only kill the patroni process, not it's children, so it will gracefully stop postgres
+
+KillMode=process
+
+# Give a reasonable amount of time for the server to start up/shut down
+
+TimeoutSec=30
+
+# Restart the service if it crashed
+
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/install_patroni/tasks/debian_packages.yaml
+++ b/roles/install_patroni/tasks/debian_packages.yaml
@@ -1,0 +1,21 @@
+---
+
+# On Debian systems, it's better to just install pipx rather than python3-pip.
+# This is because the latter is considered a dev environment, so it also pulls
+# in a bunch of build tools we don't need.
+
+- name: Install pipx to handle all of the heavy lifting
+  package:
+    name:
+    - pipx
+    state: present
+    lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
+  become: true
+
+- name: Make sure pipx is in the user's path
+  shell: |
+    pipx ensurepath

--- a/roles/install_patroni/tasks/install.yaml
+++ b/roles/install_patroni/tasks/install.yaml
@@ -1,48 +1,24 @@
 ---
 
-- name: Check for pre-existing Patroni installation
+- name: Install Patroni and any dependencies
   shell: |
-    cd {{ cluster_path }}
-    ./pgedge um list | grep -q patroni | grep -q Installed | cat
-  register: patroni_install
+    pipx install patroni[psycopg2-binary,etcd]
 
-- name: Download / install pgEdge Patroni package on server
-  shell: |
-    cd {{ cluster_path }}
-    ./pgedge um install patroni
-  when: patroni_install.stdout == ''
-  args:
-    creates: /etc/systemd/system/patroni.service
+# The service file is being installed here, but is not being enabled.
+# The setup_etcd role should do that.
 
-# This next part is a bit of a hack. We create a Python virtualenv and wrapper
-# scripts for the Patroni scripts so the virtualenv is always inherited no
-# matter how they're invoked. This should be deprecated in favor of installing
-# the official Patroni packages instead.
-
-- name: Set up Python virtual environment for Patroni + required libraries
-  pip:
-    virtualenv_command: python3 -m venv
-    virtualenv: /usr/local/patroni/env
-    virtualenv_site_packages: true
-    requirements: /usr/local/patroni/requirements.txt
+- name: Install the Patroni Systemd service file
+  template:
+    src: files/patroni.service.j2
+    dest: /etc/systemd/system/patroni.service
+    owner: "{{ ansible_user_id }}"
   become: true
 
-- name: Add additional cdiff library to Patroni virtualenv
-  pip:
-    virtualenv_command: python3 -m venv
-    virtualenv: /usr/local/patroni/env
-    name: cdiff
-  become: true
-
-- name: Create env wrappers for the main Patroni scripts
-  copy:
-    content: |
-      #!/bin/bash
-      source /usr/local/patroni/env/bin/activate
-      /usr/local/patroni/{{ item }}.py $@
-    dest: "/usr/local/bin/{{ item }}"
-    mode: 0555
-  loop:
-  - patroni
-  - patronictl
+- name: Ensure Patroni configuration directory exists owned by our user
+  file:
+    path: "{{ patroni_config_dir }}"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: 0700
   become: true

--- a/roles/install_patroni/tasks/main.yaml
+++ b/roles/install_patroni/tasks/main.yaml
@@ -4,8 +4,8 @@
 
 - name: Check for Patroni software
   stat:
-    path: "/usr/local/patroni"
-  register: patroni_software
+    path: "{{ patroni_bin_dir }}/patroni"
+  register: patroni_bin
 
 - include_tasks: install.yaml
-  when: not patroni_software.stat.exists
+  when: not patroni_bin.stat.exists

--- a/roles/install_patroni/tasks/packages.yaml
+++ b/roles/install_patroni/tasks/packages.yaml
@@ -1,26 +1,14 @@
 ---
 
-- name: Include Packages Patroni needs to run or operate
-  package:
-    name:
-    - python3-psycopg2
-    state: present
-    lock_timeout: 300
-  retries: 5
-  delay: 20
-  register: result
-  until: result is success
-  become: true
+# This file is basically a fork to install pipx depending on OS.
+#
+# Why pipx? Because Debian systems have effectively made it impossible for
+# pip to add system software anymore if it isn't packaged. Patroni packaging
+# is extremely hit or miss, while the pypi resources are almost always recent,
+# and pipx will handle the build and install so the service user can launch it.
 
-- name: Include Packages Patroni needs to run or operate on Debian systems
-  package:
-    name:
-    - python3-venv
-    state: present
-    lock_timeout: 300
-  retries: 5
-  delay: 20
-  register: result
-  until: result is success
-  become: true
+- include_tasks: debian_packages.yaml
   when: ansible_facts.os_family == 'Debian'
+
+- include_tasks: rhel_packages.yaml
+  when: ansible_facts.os_family == 'RedHat'

--- a/roles/install_patroni/tasks/rhel_packages.yaml
+++ b/roles/install_patroni/tasks/rhel_packages.yaml
@@ -1,0 +1,21 @@
+---
+
+# RHEL variants have a minimal pip install. This makes it easy to use for
+# installing pipx and nothing else.
+
+- name: Install pip to facilitate installation of pipx
+  package:
+    name:
+    - python3-pip
+    state: present
+    lock_timeout: 300
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
+  become: true
+
+- name: Install pipx and make sure it's in the user's path
+  shell: |
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath

--- a/roles/setup_etcd/defaults/main.yaml
+++ b/roles/setup_etcd/defaults/main.yaml
@@ -1,1 +1,9 @@
 ---
+
+etcd_install_dir: "{{ cluster_path }}/etcd"
+
+etcd_user: etcd
+etcd_group: etcd
+etcd_install_dir: "/usr/local/etcd"
+etcd_config_dir: "/etc/etcd"
+etcd_data_dir: "/var/lib/etcd"

--- a/roles/setup_etcd/files/etcd.yaml.j2
+++ b/roles/setup_etcd/files/etcd.yaml.j2
@@ -6,7 +6,7 @@
 {%- endfor %}
 name: {{ ansible_hostname }}
 advertise-client-urls: http://{{ inventory_hostname }}:2379
-data-dir: /var/lib/etcd/postgresql
+data-dir: {{ etcd_data_dir }}/postgresql
 initial-advertise-peer-urls: http://{{ inventory_hostname }}:2380
 initial-cluster: {{ endpoints | join(',') }}
 initial-cluster-state: new

--- a/roles/setup_etcd/tasks/main.yaml
+++ b/roles/setup_etcd/tasks/main.yaml
@@ -1,9 +1,10 @@
 ---
 
-- name: Check for etcd data directory
+- name: Check for etcd data directory for this cluster
   stat:
-    path: /var/lib/etcd/postgresql
+    path: "{{ etcd_data_dir }}/postgresql"
   register: etcd_data
+  become: true
 
 - include_tasks: setup.yaml
   when: not etcd_data.stat.exists

--- a/roles/setup_etcd/tasks/setup.yaml
+++ b/roles/setup_etcd/tasks/setup.yaml
@@ -2,18 +2,18 @@
 
 - name: Ensure etcd configuration directory exists
   file:
-    path: /etc/etcd
+    path: "{{ etcd_config_dir }}"
     state: directory
-    owner: etcd
-    group: etcd
+    owner: "{{ etcd_user }}"
+    group: "{{ etcd_group }}"
   become: true
 
 - name: Create configuration file for etcd node
   template:
     src: files/etcd.yaml.j2
-    dest: /etc/etcd/etcd.yaml
-    owner: etcd
-    group: etcd
+    dest: "{{ etcd_config_dir }}/etcd.yaml"
+    owner: "{{ etcd_user }}"
+    group: "{{ etcd_group }}"
   become: true
 
 - name: Enable and start the etcd service

--- a/roles/setup_patroni/defaults/main.yaml
+++ b/roles/setup_patroni/defaults/main.yaml
@@ -4,3 +4,6 @@ replication_user: replicator
 replication_password: secret
 synchronous_mode: false
 synchronous_mode_strict: false
+
+patroni_bin_dir: "{{ ansible_facts['user_dir'] }}/.local/bin"
+patroni_config_dir: "/etc/patroni"

--- a/roles/setup_patroni/tasks/setup.yaml
+++ b/roles/setup_patroni/tasks/setup.yaml
@@ -1,35 +1,10 @@
 ---
 
-- name: Ensure Patroni configuration directory exists owned by our user
-  file:
-    path: /etc/patroni
-    state: directory
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
-  become: true
-
 - name: Create configuration file for Patroni node
   template:
     src: files/patroni.yaml.j2
-    dest: /etc/patroni/patroni.yaml
+    dest: "{{ patroni_config_dir }}/patroni.yaml"
     mode: 0600
-
-- name: Prepare systemd for service override
-  file: 
-    path: /etc/systemd/system/patroni.service.d
-    state: directory
-  become: true
-
-- name: Add a systemd service override for pgEdge modifications
-  copy:
-    content: |
-      [Service]
-      User={{ ansible_user_id }}
-      Group={{ ansible_user_id }}
-      ExecStart=
-      ExecStart=/usr/local/bin/patroni /etc/patroni/patroni.yaml
-    dest: /etc/systemd/system/patroni.service.d/override.conf
-  become: true
 
 - name: Enable and start the Patroni service
   systemd_service:
@@ -38,3 +13,14 @@
     enabled: true
     state: started
   become: true
+
+# Patroni should restart nodes with changes which require restart, but doesn't.
+# We use the patronictl tool because a direct Postgres restart won't change the
+# "Pending restart" flag in the Patroni cluster status.
+
+- name: Restart Postgres service to incorporate configuration changes
+  shell: |
+    cd {{ patroni_bin_dir }}
+    ./patronictl -c {{ patroni_config_dir }}/patroni.yaml \
+                 restart pgedge {{ ansible_hostname }} \
+                 --force


### PR DESCRIPTION
In the case of etcd, binary packages are provided directly on GitHub. The new process downloads the tagged binary version, extracts, and installs it. The download is also verified using the published checksum on GitHub.

For Patroni, software is obtained from pypi.org via pipx. This ensures all prerequisites are also included, and the required Python environment always works as long as the binaries are invoked from the installation path.

This addresses Jira issue EE-15.

Additionally, there is now a gratuitous restart of Postgres following Patroni setup. This is to ensure all configuration changes applied to the cluster are incorporated.

This addresses Jira issue EE-13.