### PR TITLE
Fix/ee 19/add redundant pipx environment file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-TBA
+### Fixed
+
+- Added redundant path environment spec for pipx-based executables. (EE-19)
+
 
 ## v0.2.0
 

--- a/roles/install_patroni/tasks/environment.yaml
+++ b/roles/install_patroni/tasks/environment.yaml
@@ -1,0 +1,7 @@
+---
+
+- name: Add pipx / Patroni utilities to the user path
+  lineinfile:
+    path: "{{ ansible_facts['user_dir'] }}/.bashrc.d/pipx.sh"
+    line: "export PATH=${PATH}:{{ ansible_facts['user_dir'] }}/.local/bin"
+    create: true

--- a/roles/install_patroni/tasks/main.yaml
+++ b/roles/install_patroni/tasks/main.yaml
@@ -9,3 +9,5 @@
 
 - include_tasks: install.yaml
   when: not patroni_bin.stat.exists
+
+- include_tasks: environment.yaml


### PR DESCRIPTION
Add redundant .bashrc.d environment file for pipx

While pipx was a huge upgrade for getting patroni installed and operational, it doesn't specify which environment file it modifies, and doesn't offer any parameters to target one specifically. Linux distributions tend to differ on which will activate during an Ansible shell, so the only way to be sure is to use our `.bashrc.d/` environment prepping directory like other roles in this collection.

That's a lot to say we just add .local/bin the the path in a file in `.bashrc.d/` under the (so far working) assumption that `.bashrc` will run in all distributions.

Addresses Jira issue EE-19.
