### PR TITLE
The setup_patroni role will now wait for Patroni to be "ready" before success

### DIFF
--- a/roles/init_server/tasks/packages.yaml
+++ b/roles/init_server/tasks/packages.yaml
@@ -3,6 +3,7 @@
 - name: Include all the packages which should be installed everywhere
   package:
     name:
+    - jq
     - nano
     - less
     - rsync

--- a/roles/setup_patroni/tasks/setup.yaml
+++ b/roles/setup_patroni/tasks/setup.yaml
@@ -14,6 +14,21 @@
     state: started
   become: true
 
+# Wait for Patroni to become ready before sending it commands.
+
+- name: Wait until Patroni cluster is established
+  shell: |-
+    {{ ctl }} list pgedge -f json \
+        | jq -r '.[] | select(.Host == "{{ first_node_in_zone }}") | .State'
+  args:
+    chdir: "{{ patroni_bin_dir }}"
+  vars:
+    ctl: "./patronictl -c {{ patroni_config_dir }}/patroni.yaml"
+  register: patroni_status
+  retries: 30
+  delay: 10
+  until: patroni_status.stdout  == 'running'
+
 # Patroni should restart nodes with changes which require restart, but doesn't.
 # We use the patronictl tool because a direct Postgres restart won't change the
 # "Pending restart" flag in the Patroni cluster status.
@@ -22,5 +37,5 @@
   shell: |
     cd {{ patroni_bin_dir }}
     ./patronictl -c {{ patroni_config_dir }}/patroni.yaml \
-                 restart -r any pgedge {{ ansible_hostname }} \
+                 restart pgedge {{ ansible_hostname }} \
                  --force


### PR DESCRIPTION
This task exists in the new package reorganization branch but is also needed here to avoid occasional cluster deployment failures due to cluster init delays. Much of the init process happens in the background after Patroni starts, allowing dependent Ansible tasks to fail later without a specific wait step. This check just uses the patronictl tool to get the status and exits once the cluster has a registered primary node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded standard server installations to include additional system utilities (jq, nano, less, rsync) across all environments
  * Introduced automated readiness verification during database cluster initialization with intelligent retry mechanisms (up to 30 attempts with 10-second intervals)

* **Refactor**
  * Simplified database cluster restart command invocation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->