### PR TITLE
Updated path to pgEdge repo public key for repo validation.

### DIFF
--- a/roles/install_repos/tasks/rhel_repo.yaml
+++ b/roles/install_repos/tasks/rhel_repo.yaml
@@ -2,7 +2,7 @@
 
 - name: Install the pgEdge repo GPG Keys
   rpm_key:
-    key: https://dnf.pgedge.com/keys/pgedge.pub
+    key: https://dnf.pgedge.com/keys/pgedge-rsa.pub
     state: present
   become: true
 


### PR DESCRIPTION
We changed the path of our repo public key some time in the past, and this was causing installation of the repo package to fail on RHEL systems. Now using the correct `pgedge-rsa.pub` name.