### PR TITLE
Switch to pgEdge Patroni packages rather than PGDG.

### DIFF
--- a/roles/install_patroni/tasks/debian_packages.yaml
+++ b/roles/install_patroni/tasks/debian_packages.yaml
@@ -3,7 +3,7 @@
 - name: Install Patroni and DCS Python dependencies
   package:
     name:
-    - patroni
+    - pgedge-patroni
     state: present
     lock_timeout: 300
   retries: 5

--- a/roles/install_patroni/tasks/rhel_packages.yaml
+++ b/roles/install_patroni/tasks/rhel_packages.yaml
@@ -3,8 +3,8 @@
 - name: Install Patroni and DCS Python dependencies
   package:
     name:
-    - patroni
-    - patroni-etcd
+    - pgedge-patroni
+    - pgedge-patroni-etcd
     state: present
     lock_timeout: 300
   retries: 5

--- a/roles/install_repos/tasks/debian_repo.yaml
+++ b/roles/install_repos/tasks/debian_repo.yaml
@@ -27,27 +27,3 @@
   apt:
     update_cache: true
   become: true
-
-# Some pgedge Packages (postgresql-common) conflict with PGDG packages.
-# Regardless, some packages are only available from PGDG, so we include it
-# for those cases. This includes an automatic cache refresh.
-
-- name: Install Postgres Common package for PGDG repo script
-  apt:
-    name:
-    - pgedge-postgresql-common
-    state: present
-  retries: 5
-  delay: 20
-  register: result
-  until: result is success
-  become: true
-
-- name: Install and Activate the PGDG Repo
-  command:
-    argv:
-    - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-    - -y
-  args:
-    creates: "/etc/apt/sources.list.d/pgdg.sources"
-  become: true

--- a/roles/install_repos/tasks/rhel_repo.yaml
+++ b/roles/install_repos/tasks/rhel_repo.yaml
@@ -15,19 +15,3 @@
   register: result
   until: result is success
   become: true
-
-# There seems to be some kind of issue specifically with the Rocky 9 PGDG repo
-# file GPG signature, so in that single instance, disable GPG key validation.
-
-- name: Install the PGDG repo package
-  dnf:
-    name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-redhat-repo-latest.noarch.rpm
-    state: present
-    disable_gpg_check: >-
-      {{ true if ansible_distribution == 'Rocky' and
-         ansible_distribution_major_version | int == 9 else false }}
-  retries: 5
-  delay: 20
-  register: result
-  until: result is success
-  become: true


### PR DESCRIPTION
Since pgEdge now builds Patroni, we have more control than relying on the PGDG resources. This was also the only PGDG dependency, thus allowing removal of that repo as a source of possible package conflicts.