### PR TITLE
Two necessary fixes for failed tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- patroni_config_file and patroni_tls_dir now recognized by all roles.
+- backup_repo_cipher default now properly deterministic.
+
 ## v1.0.0
 
 This release is a major overhaul that revises every role in the collection.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - patroni_config_file and patroni_tls_dir now recognized by all roles.
+- Patroni replication user now connects to all databases for logical slot creation.
 - backup_repo_cipher default now properly deterministic.
 
 ## v1.0.0

--- a/roles/role_config/defaults/main.yaml
+++ b/roles/role_config/defaults/main.yaml
@@ -31,23 +31,23 @@ pg_port: 5432
 
 pg_home: >-
   {{ 
-    "/var/lib/pgsql" if ansible_os_family == "RedHat" 
+    "/var/lib/pgsql" if ansible_facts['os_family'] == "RedHat" 
     else
-    "/var/lib/postgresql" if ansible_os_family == 'Debian'
+    "/var/lib/postgresql" if ansible_facts['os_family'] == 'Debian'
   }}
 
 pg_path: >-
   {{
-    "/usr/pgsql-" + pg_version|string if ansible_os_family == "RedHat"
+    "/usr/pgsql-" + pg_version|string if ansible_facts['os_family'] == "RedHat"
      else
-    "/usr/lib/postgresql/" + pg_version|string if ansible_os_family == 'Debian'
+    "/usr/lib/postgresql/" + pg_version|string if ansible_facts['os_family'] == 'Debian'
   }}
 
 pg_data: >-
   {{ 
-    pg_home + "/" + pg_version|string + "/data" if ansible_os_family == "RedHat"
+    pg_home + "/" + pg_version|string + "/data" if ansible_facts['os_family'] == "RedHat"
     else
-    pg_home + "/" + pg_version|string + "/" + cluster_name if ansible_os_family == 'Debian' 
+    pg_home + "/" + pg_version|string + "/" + cluster_name if ansible_facts['os_family'] == 'Debian' 
   }}
 
 backup_host: ""
@@ -57,3 +57,6 @@ backup_password: secret
 backup_repo_type: ssh
 backup_repo_user: "{{ ansible_user_id }}"
 backup_repo_path: "/home/{{ ansible_user_id }}"
+
+patroni_tls_dir: "/etc/patroni/tls"
+

--- a/roles/role_config/vars/main.yaml
+++ b/roles/role_config/vars/main.yaml
@@ -29,13 +29,13 @@ backup_type: "{{ backup_repo_type if backup_repo_type in ('ssh', 's3') else 'ssh
 
 pg_service_name: >-
   {{ 
-    'pgedge-postgres-' + pg_version|string if ansible_os_family == 'RedHat' else
-    'postgresql@' + pg_version|string + '-' + cluster_name if ansible_os_family == 'Debian'
+    'pgedge-postgres-' + pg_version|string if ansible_facts['os_family'] == 'RedHat' else
+    'postgresql@' + pg_version|string + '-' + cluster_name if ansible_facts['os_family'] == 'Debian'
   }}
 
 pg_config_dir: >-
   {{ 
-    '/etc/postgresql/' + pg_version|string + '/' + cluster_name if ansible_os_family == 'Debian'
+    '/etc/postgresql/' + pg_version|string + '/' + cluster_name if ansible_facts['os_family'] == 'Debian'
     else pg_data
   }}
 
@@ -43,7 +43,7 @@ patroni_config_dir: "/etc/patroni"
 
 patroni_service_name: >-
   {{
-    'patroni@' + pg_version|string + '-' + cluster_name if ansible_os_family == 'Debian'
+    'patroni@' + pg_version|string + '-' + cluster_name if ansible_facts['os_family'] == 'Debian'
     else 'patroni'
   }}
 

--- a/roles/role_config/vars/main.yaml
+++ b/roles/role_config/vars/main.yaml
@@ -46,3 +46,9 @@ patroni_service_name: >-
     'patroni@' + pg_version|string + '-' + cluster_name if ansible_os_family == 'Debian'
     else 'patroni'
   }}
+
+patroni_config_file: >-
+  {{
+    pg_version|string + '-' + cluster_name + '.yml' if ansible_facts['os_family'] == 'Debian'
+    else 'patroni.yml'
+  }}

--- a/roles/setup_backrest/defaults/main.yaml
+++ b/roles/setup_backrest/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 
-backup_repo_cipher: "{{ lookup('password', '/dev/null length=20', seed='pgedge' + cluster_name + '-' + zone | string) }}"
+backup_repo_cipher: "{{ lookup('password', '/dev/null', length=20, seed=('pgedge' + cluster_name + '-' + zone | string)) }}"
 backup_repo_cipher_type: aes-256-cbc
 
 backup_repo_params: {}

--- a/roles/setup_patroni/defaults/main.yaml
+++ b/roles/setup_patroni/defaults/main.yaml
@@ -2,4 +2,3 @@
 
 synchronous_mode: false
 synchronous_mode_strict: false
-patroni_tls_dir: "/etc/patroni/tls"

--- a/roles/setup_patroni/templates/patroni.yml.j2
+++ b/roles/setup_patroni/templates/patroni.yml.j2
@@ -98,10 +98,10 @@ postgresql:
   - host {{ db_list }} {{ db_user }} {{ host_ip }}/32 scram-sha-256
 {% endfor %}
   # Physical replication user connections
-  - host postgres,replication {{ replication_user }} 127.0.0.1/32 scram-sha-256
+  - host {{ db_list }},replication {{ replication_user }} 127.0.0.1/32 scram-sha-256
 {% for host in nodes_in_zone %}
 {%   set host_ip = hostvars[host].ansible_default_ipv4.address %}
-  - host postgres,replication {{ replication_user }} {{ host_ip }}/32 scram-sha-256
+  - host {{ db_list }},replication {{ replication_user }} {{ host_ip }}/32 scram-sha-256
 {% endfor %}
   # Connections from proxy servers
 {% for host in proxies_in_zone %}

--- a/roles/setup_patroni/vars/main.yaml
+++ b/roles/setup_patroni/vars/main.yaml
@@ -1,7 +1,1 @@
 ---
-
-patroni_config_file: >-
-  {{
-    pg_version|string + '-' + cluster_name + '.yml' if ansible_os_family == 'Debian'
-    else 'patroni.yml'
-  }}


### PR DESCRIPTION
While working on test automation, I ran into a couple issues which required immediate fixes. I'm not quite sure how these eluded previous cluster build tests, but they were definitely present in 1.0.0.

**Fixed issue with Patroni default variables.**

The `patroni_config_file` and `patroni_tls_dir` variables worked in their respective roles, but the defaults weren't in `role_config`. Some tests failed due to runs that used these unset variables. Moving them to `role_config` from their respective roles fixed it.

**Fixed issue where the default backup repo cipher wasn't deterministic.**

The call to the Ansible `password` module was incorrectly formatted, causing non-deterministic results when generating the backup repo cipher. While we suggest the user change this, the default should at least be functional.