### PR TITLE
Added GitHub workflows to test simple and ultra HA clusters.

### DIFF
--- a/.github/workflows/simple-cluster.yml
+++ b/.github/workflows/simple-cluster.yml
@@ -1,0 +1,99 @@
+name: "E2E: Simple Cluster"
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: Target OS
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - debian12
+          - rocky9
+      environment:
+        description: Package repository environment
+        type: choice
+        required: true
+        default: release
+        options:
+          - release
+          - staging
+
+jobs:
+  test:
+    name: Simple Cluster - ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ inputs.os == 'all' && fromJSON('["debian12","rocky9"]') || fromJSON(format('["{0}"]', inputs.os)) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Increase inotify limits for systemd containers
+        run: sudo sysctl -w fs.inotify.max_user_instances=512
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Ansible
+        run: pip install ansible
+
+      - name: Generate SSH keypair
+        run: |
+          mkdir -p tests/.ssh
+          ssh-keygen -t ed25519 -f tests/.ssh/id_ed25519 -N "" -q
+          cp tests/.ssh/id_ed25519.pub tests/docker/authorized_keys
+
+      - name: Build and install collection
+        run: make install VERSION=0.0.0-dev
+
+      - name: Start containers
+        run: |
+          docker compose -p e2e -f tests/compose/simple-cluster-${{ matrix.os }}.yml up -d --build
+          sleep 5
+          docker compose -p e2e -f tests/compose/simple-cluster-${{ matrix.os }}.yml ps
+
+      - name: Wait for SSH
+        run: |
+          for host in 192.168.6.10 192.168.6.11 192.168.6.12; do
+            for i in $(seq 1 30); do
+              ssh -i tests/.ssh/id_ed25519 \
+                -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                -o ConnectTimeout=2 \
+                -o BatchMode=yes \
+                ansible@$host true 2>/dev/null && break
+              sleep 2
+            done
+          done
+
+      - name: Run playbook
+        run: |
+          ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook \
+            tests/playbooks/simple-cluster.yml \
+            -i tests/inventories/simple-cluster.yml \
+            --private-key tests/.ssh/id_ed25519 \
+            -e repo_environment=${{ inputs.environment }}
+
+      - name: Verify cluster
+        run: |
+          ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook \
+            tests/verify/verify-simple-cluster.yml \
+            -i tests/inventories/simple-cluster.yml \
+            --private-key tests/.ssh/id_ed25519
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose -p e2e -f tests/compose/simple-cluster-${{ matrix.os }}.yml logs
+
+      - name: Teardown
+        if: always()
+        run: docker compose -p e2e -f tests/compose/simple-cluster-${{ matrix.os }}.yml down -v --remove-orphans

--- a/.github/workflows/ultra-ha.yml
+++ b/.github/workflows/ultra-ha.yml
@@ -1,0 +1,99 @@
+name: "E2E: Ultra-HA"
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: Target OS
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - debian12
+          - rocky9
+      environment:
+        description: Package repository environment
+        type: choice
+        required: true
+        default: release
+        options:
+          - release
+          - staging
+
+jobs:
+  test:
+    name: Ultra-HA - ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ inputs.os == 'all' && fromJSON('["debian12","rocky9"]') || fromJSON(format('["{0}"]', inputs.os)) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Increase inotify limits for systemd containers
+        run: sudo sysctl -w fs.inotify.max_user_instances=512
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Ansible
+        run: pip install ansible
+
+      - name: Generate SSH keypair
+        run: |
+          mkdir -p tests/.ssh
+          ssh-keygen -t ed25519 -f tests/.ssh/id_ed25519 -N "" -q
+          cp tests/.ssh/id_ed25519.pub tests/docker/authorized_keys
+
+      - name: Build and install collection
+        run: make install VERSION=0.0.0-dev
+
+      - name: Start containers
+        run: |
+          docker compose -p e2e -f tests/compose/ultra-ha-${{ matrix.os }}.yml up -d --build
+          sleep 5
+          docker compose -p e2e -f tests/compose/ultra-ha-${{ matrix.os }}.yml ps
+
+      - name: Wait for SSH
+        run: |
+          for host in 192.168.6.10 192.168.6.11 192.168.6.12 192.168.6.13 192.168.6.14 192.168.6.15 192.168.6.16 192.168.6.17 192.168.6.18 192.168.6.19; do
+            for i in $(seq 1 30); do
+              ssh -i tests/.ssh/id_ed25519 \
+                -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                -o ConnectTimeout=2 \
+                -o BatchMode=yes \
+                ansible@$host true 2>/dev/null && break
+              sleep 2
+            done
+          done
+
+      - name: Run playbook
+        run: |
+          ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook \
+            tests/playbooks/ultra-ha.yml \
+            -i tests/inventories/ultra-ha.yml \
+            --private-key tests/.ssh/id_ed25519 \
+            -e repo_environment=${{ inputs.environment }}
+
+      - name: Verify cluster
+        run: |
+          ANSIBLE_CONFIG=tests/ansible.cfg ansible-playbook \
+            tests/verify/verify-ultra-ha.yml \
+            -i tests/inventories/ultra-ha.yml \
+            --private-key tests/.ssh/id_ed25519
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose -p e2e -f tests/compose/ultra-ha-${{ matrix.os }}.yml logs
+
+      - name: Teardown
+        if: always()
+        run: docker compose -p e2e -f tests/compose/ultra-ha-${{ matrix.os }}.yml down -v --remove-orphans

--- a/.github/workflows/ultra-ha.yml
+++ b/.github/workflows/ultra-ha.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Generate SSH keypair
         run: |
           mkdir -p tests/.ssh
-          ssh-keygen -t ed25519 -f tests/.ssh/id_ed25519 -N "" -q
+          if [ ! -f tests/.ssh/id_ed25519 ]; then
+            ssh-keygen -t ed25519 -f tests/.ssh/id_ed25519 -N "" -q
+          fi
           cp tests/.ssh/id_ed25519.pub tests/docker/authorized_keys
 
       - name: Build and install collection

--- a/.github/workflows/ultra-ha.yml
+++ b/.github/workflows/ultra-ha.yml
@@ -66,15 +66,20 @@ jobs:
       - name: Wait for SSH
         run: |
           for host in 192.168.6.10 192.168.6.11 192.168.6.12 192.168.6.13 192.168.6.14 192.168.6.15 192.168.6.16 192.168.6.17 192.168.6.18 192.168.6.19; do
+            ready=0
             for i in $(seq 1 30); do
               ssh -i tests/.ssh/id_ed25519 \
                 -o StrictHostKeyChecking=no \
                 -o UserKnownHostsFile=/dev/null \
                 -o ConnectTimeout=2 \
                 -o BatchMode=yes \
-                ansible@$host true 2>/dev/null && break
+                ansible@$host true 2>/dev/null && { ready=1; break; }
               sleep 2
             done
+            if [ "$ready" -ne 1 ]; then
+              echo "ERROR: SSH not ready for $host after 30 attempts" >&2
+              exit 1
+            fi
           done
 
       - name: Run playbook

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - patroni_config_file and patroni_tls_dir now recognized by all roles.
 - Patroni replication user now connects to all databases for logical slot creation.
 - backup_repo_cipher default now properly deterministic.
-- manually install Postgres contrib on Rocky systems where it may be missing.
+- manually install Postgres contrib on RHEL systems where it may be missing.
 
 ## v1.0.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - patroni_config_file and patroni_tls_dir now recognized by all roles.
 - Patroni replication user now connects to all databases for logical slot creation.
 - backup_repo_cipher default now properly deterministic.
+- manually install Postgres contrib on Rocky systems where it may be missing.
 
 ## v1.0.0
 

--- a/docs/roles/install_pgedge.md
+++ b/docs/roles/install_pgedge.md
@@ -9,6 +9,8 @@ The role performs the following tasks on inventory hosts:
 - Install the pgEdge Enterprise Postgres meta-package.
 - Install pgEdge extensions including Spock and Snowflake.
 - Install the Python Postgres adapter for database connectivity.
+- Install the Postgres contrib package (which provides `pg_stat_statements`)
+  explicitly on RHEL-based systems.
 - Ensure all components match the configured Postgres version.
 
 ## Role Dependencies
@@ -95,6 +97,11 @@ On Debian-based systems, the role uses APT to install the
 `/usr/lib/postgresql/{{ pg_version }}/`. On RHEL-based systems, the role uses
 DNF to install `pgedge-enterprise-all_{{ pg_version }}` and binaries land in
 `/usr/pgsql-{{ pg_version }}/`.
+
+RHEL-based systems also require the `pgedge-postgresql{{ pg_version }}-contrib`
+package for `pg_stat_statements` support. The role installs this package
+explicitly rather than relying on it being pulled in as a recommended
+dependency.
 
 ## Idempotency
 

--- a/roles/install_pgedge/tasks/main.yaml
+++ b/roles/install_pgedge/tasks/main.yaml
@@ -13,3 +13,18 @@
   register: result
   until: result is success
   become: true
+
+# RHEL systems don't reliably pull in the contrib package (which contains
+# pg_stat_statements) as part of the enterprise-all bundle, so install it
+# explicitly rather than relying on it being a recommended package.
+
+- name: Install the Postgres contrib package on RHEL systems
+  package:
+    name: "pgedge-postgresql{{ pg_version }}-contrib"
+    state: present
+  retries: 5
+  delay: 20
+  register: result
+  until: result is success
+  become: true
+  when: ansible_facts['os_family'] == 'RedHat'

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,14 @@
+[defaults]
+host_key_checking = False
+remote_user = ansible
+private_key_file = tests/.ssh/id_ed25519
+timeout = 30
+gathering = smart
+
+[privilege_escalation]
+become = false
+become_method = sudo
+
+[ssh_connection]
+pipelining = true
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/tests/compose/simple-cluster-debian12.yml
+++ b/tests/compose/simple-cluster-debian12.yml
@@ -1,0 +1,39 @@
+networks:
+  pgedge-test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.6.0/24
+
+x-common: &common
+  build:
+    context: ../docker
+    dockerfile: Dockerfile.debian12
+  privileged: true
+  cgroup: host
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  networks:
+    pgedge-test: {}
+
+services:
+  n1:
+    <<: *common
+    hostname: n1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.10
+
+  n2:
+    <<: *common
+    hostname: n2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.11
+
+  n3:
+    <<: *common
+    hostname: n3
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.12

--- a/tests/compose/simple-cluster-rocky9.yml
+++ b/tests/compose/simple-cluster-rocky9.yml
@@ -1,0 +1,39 @@
+networks:
+  pgedge-test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.6.0/24
+
+x-common: &common
+  build:
+    context: ../docker
+    dockerfile: Dockerfile.rocky9
+  privileged: true
+  cgroup: host
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  networks:
+    pgedge-test: {}
+
+services:
+  n1:
+    <<: *common
+    hostname: n1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.10
+
+  n2:
+    <<: *common
+    hostname: n2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.11
+
+  n3:
+    <<: *common
+    hostname: n3
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.12

--- a/tests/compose/ultra-ha-debian12.yml
+++ b/tests/compose/ultra-ha-debian12.yml
@@ -1,0 +1,88 @@
+networks:
+  pgedge-test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.6.0/24
+
+x-common: &common
+  build:
+    context: ../docker
+    dockerfile: Dockerfile.debian12
+  privileged: true
+  cgroup: host
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  networks:
+    pgedge-test: {}
+
+services:
+  pgedge1:
+    <<: *common
+    hostname: pgedge1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.10
+
+  pgedge2:
+    <<: *common
+    hostname: pgedge2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.11
+
+  pgedge3:
+    <<: *common
+    hostname: pgedge3
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.12
+
+  pgedge4:
+    <<: *common
+    hostname: pgedge4
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.13
+
+  pgedge5:
+    <<: *common
+    hostname: pgedge5
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.14
+
+  pgedge6:
+    <<: *common
+    hostname: pgedge6
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.15
+
+  haproxy1:
+    <<: *common
+    hostname: haproxy1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.16
+
+  haproxy2:
+    <<: *common
+    hostname: haproxy2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.17
+
+  backup1:
+    <<: *common
+    hostname: backup1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.18
+
+  backup2:
+    <<: *common
+    hostname: backup2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.19

--- a/tests/compose/ultra-ha-rocky9.yml
+++ b/tests/compose/ultra-ha-rocky9.yml
@@ -1,0 +1,88 @@
+networks:
+  pgedge-test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.6.0/24
+
+x-common: &common
+  build:
+    context: ../docker
+    dockerfile: Dockerfile.rocky9
+  privileged: true
+  cgroup: host
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  networks:
+    pgedge-test: {}
+
+services:
+  pgedge1:
+    <<: *common
+    hostname: pgedge1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.10
+
+  pgedge2:
+    <<: *common
+    hostname: pgedge2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.11
+
+  pgedge3:
+    <<: *common
+    hostname: pgedge3
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.12
+
+  pgedge4:
+    <<: *common
+    hostname: pgedge4
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.13
+
+  pgedge5:
+    <<: *common
+    hostname: pgedge5
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.14
+
+  pgedge6:
+    <<: *common
+    hostname: pgedge6
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.15
+
+  haproxy1:
+    <<: *common
+    hostname: haproxy1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.16
+
+  haproxy2:
+    <<: *common
+    hostname: haproxy2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.17
+
+  backup1:
+    <<: *common
+    hostname: backup1
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.18
+
+  backup2:
+    <<: *common
+    hostname: backup2
+    networks:
+      pgedge-test:
+        ipv4_address: 192.168.6.19

--- a/tests/docker/Dockerfile.debian12
+++ b/tests/docker/Dockerfile.debian12
@@ -1,0 +1,23 @@
+FROM debian:12
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    systemd systemd-sysv dbus openssh-server \
+    python3 python3-apt sudo iproute2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash ansible && \
+    echo 'ansible ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible && \
+    chmod 440 /etc/sudoers.d/ansible && \
+    mkdir -p /home/ansible/.ssh && \
+    chown ansible:ansible /home/ansible/.ssh && \
+    chmod 700 /home/ansible/.ssh
+
+COPY authorized_keys /home/ansible/.ssh/authorized_keys
+RUN chown ansible:ansible /home/ansible/.ssh/authorized_keys && \
+    chmod 600 /home/ansible/.ssh/authorized_keys
+
+RUN mkdir -p /run/sshd && systemctl enable ssh
+
+CMD ["/usr/sbin/init"]

--- a/tests/docker/Dockerfile.rocky9
+++ b/tests/docker/Dockerfile.rocky9
@@ -1,5 +1,16 @@
 FROM rockylinux:9
 
+RUN cat <<EOF > /etc/dnf/dnf.conf
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+best=True
+skip_if_unavailable=False
+max_parallel_downloads=10
+fastestmirror=True
+EOF
+
 RUN dnf -y install systemd openssh-server openssh-clients python3 sudo iproute passwd && \
     dnf clean all
 

--- a/tests/docker/Dockerfile.rocky9
+++ b/tests/docker/Dockerfile.rocky9
@@ -1,0 +1,19 @@
+FROM rockylinux:9
+
+RUN dnf -y install systemd openssh-server openssh-clients python3 sudo iproute passwd && \
+    dnf clean all
+
+RUN useradd -m -s /bin/bash ansible && \
+    echo 'ansible ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible && \
+    chmod 440 /etc/sudoers.d/ansible && \
+    mkdir -p /home/ansible/.ssh && \
+    chown ansible:ansible /home/ansible/.ssh && \
+    chmod 700 /home/ansible/.ssh
+
+COPY authorized_keys /home/ansible/.ssh/authorized_keys
+RUN chown ansible:ansible /home/ansible/.ssh/authorized_keys && \
+    chmod 600 /home/ansible/.ssh/authorized_keys
+
+RUN ssh-keygen -A && systemctl enable sshd
+
+CMD ["/usr/sbin/init"]

--- a/tests/inventories/simple-cluster.yml
+++ b/tests/inventories/simple-cluster.yml
@@ -1,0 +1,21 @@
+all:
+  vars:
+    ansible_user: ansible
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+    debug_pgedge: false
+    disable_selinux: false
+    manage_host_file: false
+
+pgedge:
+  vars:
+    db_password: TestPass123
+    pgedge_password: TestPass456
+    replication_password: TestPass789
+    backup_password: TestBackup321
+  hosts:
+    192.168.6.10:
+      zone: 1
+    192.168.6.11:
+      zone: 2
+    192.168.6.12:
+      zone: 3

--- a/tests/inventories/ultra-ha.yml
+++ b/tests/inventories/ultra-ha.yml
@@ -1,0 +1,42 @@
+all:
+  vars:
+    ansible_user: ansible
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+    debug_pgedge: false
+    disable_selinux: false
+    manage_host_file: false
+
+pgedge:
+  vars:
+    db_password: TestPass123
+    pgedge_password: TestPass456
+    replication_password: TestPass789
+    backup_password: TestBackup321
+    is_ha_cluster: true
+  hosts:
+    192.168.6.10:
+      zone: 1
+    192.168.6.11:
+      zone: 1
+    192.168.6.12:
+      zone: 1
+    192.168.6.13:
+      zone: 2
+    192.168.6.14:
+      zone: 2
+    192.168.6.15:
+      zone: 2
+
+haproxy:
+  hosts:
+    192.168.6.16:
+      zone: 1
+    192.168.6.17:
+      zone: 2
+
+backup:
+  hosts:
+    192.168.6.18:
+      zone: 1
+    192.168.6.19:
+      zone: 2

--- a/tests/playbooks/simple-cluster.yml
+++ b/tests/playbooks/simple-cluster.yml
@@ -1,0 +1,25 @@
+---
+
+- hosts: pgedge
+  any_errors_fatal: true
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: init_server
+
+  - include_role:
+      name: install_repos
+
+  - include_tasks: switch-repo.yml
+
+  - include_role:
+      name: install_pgedge
+
+  - include_role:
+      name: setup_postgres
+
+  - include_role:
+      name: setup_pgedge

--- a/tests/playbooks/switch-repo.yml
+++ b/tests/playbooks/switch-repo.yml
@@ -8,6 +8,12 @@
     when: ansible_facts['os_family'] == 'RedHat'
     become: true
 
+  - name: Update DNF cache after repo switch
+    dnf:
+      update_cache: true
+    when: ansible_facts['os_family'] == 'RedHat'
+    become: true
+
   - name: Switch pgEdge apt repo
     command: sed -i 's/release/{{ repo_environment }}/' /etc/apt/sources.list.d/pgedge.sources
     when: ansible_facts['os_family'] == 'Debian'

--- a/tests/playbooks/switch-repo.yml
+++ b/tests/playbooks/switch-repo.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Switch pgEdge repo from release to {{ repo_environment }}
+  when: repo_environment is defined and repo_environment != 'release'
+  block:
+  - name: Switch pgEdge yum repo
+    command: sed -i 's/release/{{ repo_environment }}/' /etc/yum.repos.d/pgedge.repo
+    when: ansible_facts['os_family'] == 'RedHat'
+    become: true
+
+  - name: Switch pgEdge apt repo
+    command: sed -i 's/release/{{ repo_environment }}/' /etc/apt/sources.list.d/pgedge.sources
+    when: ansible_facts['os_family'] == 'Debian'
+    become: true
+
+  - name: Update APT cache after repo switch
+    apt:
+      update_cache: true
+    when: ansible_facts['os_family'] == 'Debian'
+    become: true

--- a/tests/playbooks/ultra-ha.yml
+++ b/tests/playbooks/ultra-ha.yml
@@ -1,0 +1,82 @@
+---
+
+- hosts: all
+  any_errors_fatal: true
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: init_server
+
+- hosts: pgedge
+  any_errors_fatal: true
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: install_repos
+
+  - include_tasks: switch-repo.yml
+
+  - include_role:
+      name: install_pgedge
+
+  - include_role:
+      name: setup_postgres
+
+  - include_role:
+      name: install_etcd
+
+  - include_role:
+      name: install_patroni
+
+  - include_role:
+      name: install_backrest
+
+  - include_role:
+      name: setup_etcd
+
+  - include_role:
+      name: setup_patroni
+
+  - include_role:
+      name: setup_backrest
+
+- hosts: haproxy
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: setup_haproxy
+
+- hosts: pgedge
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: setup_pgedge
+
+- hosts: backup
+
+  collections:
+  - pgedge.platform
+
+  tasks:
+  - include_role:
+      name: install_repos
+
+  - include_tasks: switch-repo.yml
+
+  - include_role:
+      name: install_backrest
+
+  - include_role:
+      name: setup_backrest

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -82,9 +82,9 @@ echo "==> Step 4: Waiting for SSH on all containers..."
 # Extract IPs from inventory
 HOSTS=$(grep -oP '192\.168\.6\.\d+' "$INVENTORY" | sort -u)
 MAX_WAIT=60
-ELAPSED=0
 
 for host in $HOSTS; do
+  ELAPSED=0
   while ! ssh -i "$SCRIPT_DIR/.ssh/id_ed25519" \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  echo "Usage: $0 <scenario> <os> [--keep]"
+  echo "  scenario: simple-cluster | ultra-ha"
+  echo "  os:       debian12 | rocky9"
+  echo "  --keep:   don't tear down containers after test"
+  exit 1
+}
+
+SCENARIO="${1:-}"
+OS="${2:-}"
+KEEP=false
+
+for arg in "$@"; do
+  if [ "$arg" = "--keep" ]; then
+    KEEP=true
+  fi
+done
+
+if [ -z "$SCENARIO" ] || [ -z "$OS" ]; then
+  usage
+fi
+
+COMPOSE_FILE="$SCRIPT_DIR/compose/${SCENARIO}-${OS}.yml"
+INVENTORY="$SCRIPT_DIR/inventories/${SCENARIO}.yml"
+PLAYBOOK="$PROJECT_DIR/sample-playbooks/${SCENARIO}/playbook.yaml"
+VERIFY_PLAYBOOK="$SCRIPT_DIR/verify/verify-${SCENARIO}.yml"
+PROJECT_NAME="pgedge-test-${SCENARIO}-${OS}"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "ERROR: Compose file not found: $COMPOSE_FILE"
+  exit 1
+fi
+
+if [ ! -f "$INVENTORY" ]; then
+  echo "ERROR: Inventory not found: $INVENTORY"
+  exit 1
+fi
+
+if [ ! -f "$PLAYBOOK" ]; then
+  echo "ERROR: Playbook not found: $PLAYBOOK"
+  exit 1
+fi
+
+cleanup() {
+  if [ "$KEEP" = false ]; then
+    echo "==> Tearing down containers..."
+    docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+  else
+    echo "==> Keeping containers running (use 'docker compose -p $PROJECT_NAME -f $COMPOSE_FILE down -v' to clean up)"
+  fi
+}
+
+trap cleanup EXIT
+
+# Step 1: Generate SSH keypair and copy to Docker build context
+echo "==> Step 1: Ensuring SSH keypair exists..."
+mkdir -p "$SCRIPT_DIR/.ssh"
+if [ ! -f "$SCRIPT_DIR/.ssh/id_ed25519" ]; then
+  ssh-keygen -t ed25519 -f "$SCRIPT_DIR/.ssh/id_ed25519" -N "" -q
+  echo "    Generated new SSH keypair"
+else
+  echo "    Using existing SSH keypair"
+fi
+cp "$SCRIPT_DIR/.ssh/id_ed25519.pub" "$SCRIPT_DIR/docker/authorized_keys"
+
+# Step 2: Build containers
+echo "==> Step 2: Building Docker images..."
+docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" build
+
+# Step 3: Start containers
+echo "==> Step 3: Starting containers..."
+docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d
+
+# Step 4: Wait for SSH
+echo "==> Step 4: Waiting for SSH on all containers..."
+# Extract IPs from inventory
+HOSTS=$(grep -oP '192\.168\.6\.\d+' "$INVENTORY" | sort -u)
+MAX_WAIT=60
+ELAPSED=0
+
+for host in $HOSTS; do
+  while ! ssh -i "$SCRIPT_DIR/.ssh/id_ed25519" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=2 \
+    -o BatchMode=yes \
+    ansible@"$host" true 2>/dev/null; do
+    ELAPSED=$((ELAPSED + 2))
+    if [ $ELAPSED -ge $MAX_WAIT ]; then
+      echo "ERROR: Timed out waiting for SSH on $host"
+      exit 1
+    fi
+    sleep 2
+  done
+  echo "    SSH ready on $host"
+done
+
+# Step 5: Build and install Ansible collection
+echo "==> Step 5: Building and installing Ansible collection..."
+cd "$PROJECT_DIR"
+make install
+
+# Step 6: Install Galaxy dependencies
+echo "==> Step 6: Installing Galaxy dependencies..."
+ansible-galaxy collection install -r "$PROJECT_DIR/galaxy.template.yml" --force 2>/dev/null || \
+  echo "    Warning: Some Galaxy dependencies may not have installed"
+
+# Step 7: Run the sample playbook
+echo "==> Step 7: Running playbook: $PLAYBOOK"
+ANSIBLE_CONFIG="$SCRIPT_DIR/ansible.cfg" ansible-playbook \
+  "$PLAYBOOK" \
+  -i "$INVENTORY" \
+  --private-key "$SCRIPT_DIR/.ssh/id_ed25519" \
+  -v
+
+# Step 8: Run verification
+if [ -f "$VERIFY_PLAYBOOK" ]; then
+  echo "==> Step 8: Running verification playbook..."
+  ANSIBLE_CONFIG="$SCRIPT_DIR/ansible.cfg" ansible-playbook \
+    "$VERIFY_PLAYBOOK" \
+    -i "$INVENTORY" \
+    --private-key "$SCRIPT_DIR/.ssh/id_ed25519" \
+    -v
+else
+  echo "==> Step 8: No verification playbook found, skipping"
+fi
+
+echo ""
+echo "========================================="
+echo "  TEST PASSED: ${SCENARIO} on ${OS}"
+echo "========================================="

--- a/tests/verify/verify-simple-cluster.yml
+++ b/tests/verify/verify-simple-cluster.yml
@@ -1,0 +1,95 @@
+---
+- hosts: pgedge
+  become: true
+
+  collections:
+  - pgedge.platform
+
+  vars:
+    pg_version: 17
+    cluster_name: demo
+    db_names:
+    - demo
+    db_user: admin
+    db_password: TestPass123
+    pgedge_user: pgedge
+    pgedge_password: TestPass456
+
+  environment:
+    PATH: "/usr/pgsql-{{ pg_version }}/bin:/usr/lib/postgresql/{{ pg_version }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  tasks:
+  - name: Check Postgres is accepting connections
+    command: >
+      pg_isready -h 127.0.0.1 -p {{ pg_port | default(5432) }}
+    changed_when: false
+
+  - name: Check Spock extension is installed
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT extname FROM pg_extension WHERE extname='spock'"
+    register: spock_ext
+    changed_when: false
+
+  - name: Assert Spock extension exists
+    assert:
+      that: "'spock' in spock_ext.stdout"
+      fail_msg: "Spock extension not found in database demo"
+
+  - name: Check Spock node exists
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT count(*) FROM spock.node"
+    register: spock_node_count
+    changed_when: false
+
+  - name: Assert Spock node is created
+    assert:
+      that: "spock_node_count.stdout | int >= 1"
+      fail_msg: "No Spock node found"
+
+  - name: Check Spock subscriptions
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT count(*) FROM spock.subscription"
+    register: sub_count
+    changed_when: false
+
+  - name: Assert subscriptions exist
+    assert:
+      that: "sub_count.stdout | int == (groups['pgedge'] | length) - 1"
+      fail_msg: >
+        Expected {{ (groups['pgedge'] | length) - 1 }} subscriptions,
+        got {{ sub_count.stdout }}
+
+  # Replication test: create table and insert data on first node
+  - name: Create test table for replication check
+    become_user: postgres
+    command: >
+      psql -d demo -c "
+        CREATE TABLE IF NOT EXISTS repl_test (id serial PRIMARY KEY, val text);
+        INSERT INTO repl_test (val) VALUES ('hello_from_{{ inventory_hostname }}');
+      "
+    run_once: true
+    changed_when: false
+
+  - name: Wait for replication
+    pause:
+      seconds: 5
+    run_once: true
+
+  - name: Verify replicated data exists
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT count(*) FROM repl_test"
+    register: repl_count
+    changed_when: false
+
+  - name: Assert replication worked
+    assert:
+      that: "repl_count.stdout | int >= 1"
+      fail_msg: "Replication test failed: no rows found in repl_test on {{ inventory_hostname }}"
+
+  - name: Show replication success
+    debug:
+      msg: "Replication verified on {{ inventory_hostname }}: {{ repl_count.stdout }} row(s) in repl_test"

--- a/tests/verify/verify-ultra-ha.yml
+++ b/tests/verify/verify-ultra-ha.yml
@@ -1,0 +1,146 @@
+---
+# Verify pgedge nodes: Postgres, etcd, Patroni, Spock replication
+- hosts: pgedge
+  become: true
+
+  collections:
+  - pgedge.platform
+
+  vars:
+    pg_version: 17
+    cluster_name: demo
+    db_names:
+    - demo
+    db_user: admin
+    db_password: TestPass123
+    pgedge_user: pgedge
+    pgedge_password: TestPass456
+    patroni_svc: >-
+      {{ 'patroni@' + pg_version|string + '-' + cluster_name if ansible_os_family == 'Debian'
+         else 'patroni' }}
+    nodes_in_zone: >-
+      {{ groups['pgedge'] |
+      map('extract', hostvars) |
+      selectattr('zone', 'eq', zone) |
+      map(attribute='inventory_hostname') | list }}
+    first_node_in_zone: "{{ nodes_in_zone | first }}"
+
+  environment:
+    PATH: "/usr/pgsql-{{ pg_version }}/bin:/usr/lib/postgresql/{{ pg_version }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  tasks:
+  - name: Check Patroni is running
+    command: systemctl is-active {{ patroni_svc }}
+    changed_when: false
+
+  - name: Check Patroni cluster status
+    uri:
+      url: "http://127.0.0.1:8008/cluster"
+      return_content: true
+    register: patroni_cluster
+
+  - name: Assert Patroni cluster has a leader
+    assert:
+      that: "patroni_cluster.json.members | selectattr('role', 'eq', 'leader') | list | length == 1"
+      fail_msg: "No Patroni leader found in cluster"
+    run_once: true
+
+  - name: Check Postgres is accepting connections
+    command: >
+      pg_isready -h 127.0.0.1 -p {{ pg_port | default(5432) }}
+    changed_when: false
+    # Only primaries will accept connections; replicas may be in recovery
+    ignore_errors: true
+
+  # Run Spock checks only on zone primaries (first node in each zone)
+  - name: Check Spock extension on primary
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT extname FROM pg_extension WHERE extname='spock'"
+    register: spock_ext
+    changed_when: false
+    when: inventory_hostname == first_node_in_zone
+
+  - name: Assert Spock extension exists on primary
+    assert:
+      that: "'spock' in spock_ext.stdout"
+      fail_msg: "Spock extension not found"
+    when: inventory_hostname == first_node_in_zone
+
+  - name: Check Spock subscriptions on primary
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT count(*) FROM spock.subscription"
+    register: sub_count
+    changed_when: false
+    when: inventory_hostname == first_node_in_zone
+
+  - name: Show Spock subscription count
+    debug:
+      msg: "{{ inventory_hostname }}: {{ sub_count.stdout }} subscription(s)"
+    when: inventory_hostname == first_node_in_zone
+
+  # Replication test between zone primaries
+  - name: Create test table for replication
+    become_user: postgres
+    command: >
+      psql -d demo -c "
+        CREATE TABLE IF NOT EXISTS repl_test (id serial PRIMARY KEY, val text);
+        INSERT INTO repl_test (val) VALUES ('hello_from_zone_{{ zone }}');
+      "
+    changed_when: false
+    when: inventory_hostname == first_node_in_zone
+    run_once: true
+
+  - name: Wait for replication
+    pause:
+      seconds: 5
+    run_once: true
+
+  - name: Verify replicated data on zone primaries
+    become_user: postgres
+    command: >
+      psql -d demo -t -A -c "SELECT count(*) FROM repl_test"
+    register: repl_count
+    changed_when: false
+    when: inventory_hostname == first_node_in_zone
+
+  - name: Assert replication worked
+    assert:
+      that: "repl_count.stdout | int >= 1"
+      fail_msg: "Replication test failed on {{ inventory_hostname }}"
+    when: inventory_hostname == first_node_in_zone
+
+# Verify HAProxy nodes
+- hosts: haproxy
+  become: true
+
+  tasks:
+  - name: Check HAProxy is running
+    command: systemctl is-active haproxy
+    changed_when: false
+
+  - name: Check HAProxy is listening on port 5432
+    wait_for:
+      port: 5432
+      host: 127.0.0.1
+      timeout: 5
+
+  - name: Show HAProxy status
+    debug:
+      msg: "HAProxy running on {{ inventory_hostname }}"
+
+# Verify Backup nodes
+- hosts: backup
+  become: true
+
+  tasks:
+  - name: Check pgbackrest info
+    command: pgbackrest info
+    register: backrest_info
+    changed_when: false
+    ignore_errors: true
+
+  - name: Show backup status
+    debug:
+      msg: "pgbackrest info output: {{ backrest_info.stdout_lines | default(['not available']) }}"


### PR DESCRIPTION
Something that's been missing for a while: tests!

Provides two new workflows:

* E2E: Simple Cluster - sets up a 3-node Spock cluster and verifies functioning replication through Spock.
* E2E: Ultra-HA - Sets up a 10-node cluster with two regions, each containing 3 Spock nodes using physical replication, 1 HAProxy node, and 1 pgBackRest node. Then verifies functioning replication through Spock.

The new workflows accept two inputs:

* os: can be rocky9 or debian12, other variants pending.
* environment: Currently only "release" and "staging" for targeting the correct repo sources.

Co-authored by: Jimmy Angelakos

Addresses issue EE-27.