### PR TITLE
semvar fixes for Ansible Galaxy install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 #   make install
 #
 
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "0.0.0-dev")
 DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 TARGET := $(DIR)/pgedge-platform-$(VERSION).tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 #   make install
 #
 
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "0.0.0-dev")
+VERSION ?= $(shell { git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev"; } | sed 's/^v//')
 DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 TARGET := $(DIR)/pgedge-platform-$(VERSION).tar.gz
 


### PR DESCRIPTION
Ansible Galaxy didn't like the "v" prepended to the version.  Also made version detection fallback to a semvar acceptable 0.0.0-dev instead of simply "dev".