### PR TITLE
Collect SSH host keys on target hosts instead of the Ansible controller

### DIFF
--- a/roles/init_server/tasks/ssh.yaml
+++ b/roles/init_server/tasks/ssh.yaml
@@ -22,3 +22,9 @@
     flat: yes
   become: true
   become_user: "{{ os_user }}"
+
+- name: Retrieve this server's SSH host public key
+  fetch:
+    src: /etc/ssh/ssh_host_ed25519_key.pub
+    dest: "host-keys/{{ inventory_hostname }}.host"
+    flat: yes

--- a/roles/setup_backrest/tasks/setup_server.yaml
+++ b/roles/setup_backrest/tasks/setup_server.yaml
@@ -25,7 +25,7 @@
   known_hosts:
     name: "{{ item }}"
     state: present
-    key: "{{ lookup('pipe', 'ssh-keyscan {{ item }} | grep -v ''^\\#''') }}"
+    key: "{{ item }} {{ lookup('file', 'host-keys/' + item + '.host') }}"
     hash_host: false
   become: true
   become_user: "{{ backup_repo_user }}"

--- a/roles/setup_backrest/tasks/setup_ssh_access.yaml
+++ b/roles/setup_backrest/tasks/setup_ssh_access.yaml
@@ -16,7 +16,7 @@
   known_hosts:
     name: "{{ item }}"
     state: present
-    key: "{{ lookup('pipe', 'ssh-keyscan {{ item }} | grep -v ''^\\#''') }}"
+    key: "{{ item }} {{ lookup('file', 'host-keys/' + item + '.host') }}"
     hash_host: false
   loop: "{{ backups_in_zone + [backup_host] | select }}"
   become: true


### PR DESCRIPTION
The pipe lookup runs ssh-keyscan as a bare shell command on the controller, and ssh-keyscan doesn't support using jump hosts. To work in situations where there is a jump host, fetch the SSH host public key from /etc/ssh/ssh_host_ed25519_key.pub during server setup (i.e. init_server task) and use the resulting file in the couple of known_hosts tasks.