### PR TITLE
Add database tablespace support 

### DIFF
--- a/docs/configure_playbook.md
+++ b/docs/configure_playbook.md
@@ -94,8 +94,8 @@ The following inventory creates multiple databases with custom user accounts:
 pgedge:
   vars:
     db_names:
-      - app_db
-      - reporting_db
+      - name: app_db
+      - name: reporting_db
     db_user: appuser
     db_password: "{{ vault_db_password }}"
     pgedge_user: replication

--- a/docs/simple_cluster.md
+++ b/docs/simple_cluster.md
@@ -78,7 +78,7 @@ pgedge:
   vars:
     pg_version: 17
     db_names:
-      - mydb
+      - name:  mydb
     db_user: myuser
     db_password: mypassword
 ```

--- a/galaxy.template.yml
+++ b/galaxy.template.yml
@@ -23,6 +23,7 @@ dependencies:
   "community.postgresql": ">=2.4.0"
   "community.general": ">=8.2.0"
   "community.crypto": ">=2.4.0"
+  "ansible.posix": ">=1.5.0"
 
 repository: https://github.com/pgEdge/pgedge-ansible
 

--- a/roles/role_config/defaults/main.yaml
+++ b/roles/role_config/defaults/main.yaml
@@ -9,7 +9,7 @@ spock_version: "5.0.4"
 tls_validity_days: 3560
 
 db_names:
-- demo
+- name: demo
 db_user: admin
 db_password: secret
 

--- a/roles/setup_patroni/templates/patroni.yml.j2
+++ b/roles/setup_patroni/templates/patroni.yml.j2
@@ -1,7 +1,7 @@
 {%- set ip_mask = (ansible_default_ipv4.address + '/' +
       ansible_default_ipv4.netmask) |
       ansible.utils.ipaddr('host/prefix') %}
-{%- set db_list = (db_names + ['postgres']) | join(',') %}
+{%- set db_list = (db_names | map(attribute='name') + ['postgres']) | join(',') %}
 scope: "{{ pg_version }}-{{ cluster_name }}"
 namespace: /db/
 name: {{ ansible_hostname }}

--- a/roles/setup_pgedge/tasks/ha_setup.yaml
+++ b/roles/setup_pgedge/tasks/ha_setup.yaml
@@ -25,7 +25,7 @@
 - name: Set up Spock to manage node metadata
   community.postgresql.postgresql_query:
     login_port: "{{ pg_port }}"
-    login_db: "{{ item }}"
+    login_db: "{{ item.name }}"
     login_unix_socket: /var/run/postgresql
     query: |-
       DO $$
@@ -39,7 +39,7 @@
       END; $$ LANGUAGE plpgsql;
     named_args:
       node_name: "edge{{ zone }}"
-      dsn: "host={{ subscribe_target }} user={{ pgedge_user }} dbname={{ item }} port={{ proxy_port }}"
+      dsn: "host={{ subscribe_target }} user={{ pgedge_user }} dbname={{ item.name }} port={{ proxy_port }}"
   loop: "{{ db_names }}"
   become: true
   become_user: postgres
@@ -84,7 +84,7 @@
       {{ remote_proxy_node if remote_proxy_node > ''
          else remote_proxies | first if remote_proxies
          else remote_first_node }}
-  loop: "{{ zone_list | reject('equalto', zone) | product(db_names) | list }}"
+  loop: "{{ zone_list | reject('equalto', zone) | product(db_names | map(attribute='name')) | list }}"
   become: true
   become_user: postgres
 
@@ -95,7 +95,7 @@
 - name: Wait for subscriptions to sync
   community.postgresql.postgresql_query:
     login_port: "{{ pg_port }}"
-    login_db: "{{ item }}"
+    login_db: "{{ item.name }}"
     login_unix_socket: /var/run/postgresql
     query: |
       SELECT spock.sub_wait_for_sync(subscription_name := sub_name)

--- a/roles/setup_pgedge/tasks/setup.yaml
+++ b/roles/setup_pgedge/tasks/setup.yaml
@@ -3,7 +3,7 @@
 - name: Set up Spock to manage node metadata
   community.postgresql.postgresql_query:
     login_port: "{{ pg_port }}"
-    login_db: "{{ item }}"
+    login_db: "{{ item.name }}"
     login_unix_socket: /var/run/postgresql
     query: |-
       DO $$
@@ -17,7 +17,7 @@
       END; $$ LANGUAGE plpgsql;
     named_args:
       node_name: "edge{{ zone }}"
-      dsn: "host={{ inventory_hostname }} user={{ pgedge_user }} dbname={{ item }} port={{ pg_port }}"
+      dsn: "host={{ inventory_hostname }} user={{ pgedge_user }} dbname={{ item.name }} port={{ pg_port }}"
   loop: "{{ db_names }}"
   become: true
   become_user: postgres
@@ -48,6 +48,6 @@
     remote_zone: "{{ hostvars[item.0]['zone'] }}"
   loop: >-
     {{ groups['pgedge'] | reject('equalto', inventory_hostname) | 
-    product(db_names) | list }}
+    product(db_names | map(attribute='name')) | list }}
   become: true
   become_user: postgres

--- a/roles/setup_postgres/tasks/common_setup.yaml
+++ b/roles/setup_postgres/tasks/common_setup.yaml
@@ -27,9 +27,33 @@
 # Since we created the instance using the default 'postgres' database name,
 # create all requested databases and init the spock and snowflake extensions.
 
+- name: Create tablespace directories
+  file:
+    path: "{{ item.tablespace.location }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0700'
+  loop: "{{ db_names }}"
+  become: true
+  when: item.tablespace is defined
+
+- name: Create tablespaces
+  community.postgresql.postgresql_tablespace:
+    name: "{{ item.tablespace.name }}"
+    location: "{{ item.tablespace.location }}"
+    state: present
+    login_port: "{{ pg_port }}"
+    login_unix_socket: /var/run/postgresql
+  loop: "{{ db_names }}"
+  become: true
+  become_user: postgres
+  when: item.tablespace is defined
+
 - name: Create each of the requested databases
   community.postgresql.postgresql_db:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
+    tablespace: "{{ item.tablespace.name | default(omit) }}"
     login_port: "{{ pg_port }}"
     login_unix_socket: /var/run/postgresql
   loop: "{{ db_names }}"
@@ -42,6 +66,6 @@
     login_port: "{{ pg_port }}"
     login_db: "{{ item.1 }}"
     login_unix_socket: /var/run/postgresql
-  loop: "{{ ['spock', 'snowflake'] | product(db_names) | list }}"
+  loop: "{{ ['spock', 'snowflake'] | product(db_names | map(attribute='name')) | list }}"
   become: true
   become_user: postgres

--- a/roles/setup_postgres/tasks/prep_instance.yaml
+++ b/roles/setup_postgres/tasks/prep_instance.yaml
@@ -90,7 +90,7 @@
     dest: "{{ pg_config_dir }}/pg_hba.conf"
     contype: host
     users: "{{ pgedge_user + ',' + db_user }}"
-    databases: "{{ (db_names + ['postgres']) | join(',') }}"
+    databases: "{{ (db_names | map(attribute='name') + ['postgres']) | join(',') }}"
     method: scram-sha-256
     source: "{{ hostvars[item].ansible_default_ipv4.address }}/32"
   loop: "{{ groups['pgedge'] }}"

--- a/roles/setup_postgres/tasks/setup.yaml
+++ b/roles/setup_postgres/tasks/setup.yaml
@@ -13,6 +13,13 @@
     enabled: true
   become: true
 
+- name: Reload the Postgres service to incorporate any access changes, helpful in case if service is already running
+  systemd_service:
+    name: "{{ pg_service_name }}"
+    state: reloaded
+    enabled: true
+  become: true
+
 # Include all other common steps for a standard Postgres node
 
 - name: Include common Postgres setup steps


### PR DESCRIPTION
One of our customers relies on Ansible to manage their production environment, which hosts multiple databases. They requested that each database be stored in a separate directory. To support this requirement, the pgEdge Ansible scripts were enhanced to add support for creating databases in separate tablespaces. These changes are deployed to the customer system and working fine.

Example:

inventory.yaml

```
...
    db_names:
      - name: db1
        tablespace:
          name: db1_ts
          location: /db/db1
      - name: db2
        tablespace:
          name: db2_ts
          location: /db/db2
...
```

If you approve the idea I can work more on add changes for the readme or anything else required by you.
